### PR TITLE
Add error parsing to class properties

### DIFF
--- a/sportsreference/decorators.py
+++ b/sportsreference/decorators.py
@@ -1,0 +1,34 @@
+def int_property_decorator(func):
+    @property
+    def wrapper(*args):
+        value = func(*args)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            # If there is no value, default to None. None is statistically
+            # different from 0 as a player/team who played an entire game and
+            # contributed nothing is different from one who didn't play at all.
+            # This enables flexibility for end-users to decide whether they
+            # want to fill the empty value with any specific number (such as 0
+            # or an average/median for the category) or keep it empty depending
+            # on their use-case.
+            return None
+    return wrapper
+
+
+def float_property_decorator(func):
+    @property
+    def wrapper(*args):
+        value = func(*args)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            # If there is no value, default to None. None is statistically
+            # different from 0 as a player/team who played an entire game and
+            # contributed nothing is different from one who didn't play at all.
+            # This enables flexibility for end-users to decide whether they
+            # want to fill the empty value with any specific number (such as 0
+            # or an average/median for the category) or keep it empty depending
+            # on their use-case.
+            return None
+    return wrapper

--- a/sportsreference/decorators.py
+++ b/sportsreference/decorators.py
@@ -1,5 +1,9 @@
+from functools import wraps
+
+
 def int_property_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         value = func(*args)
         try:
@@ -18,6 +22,7 @@ def int_property_decorator(func):
 
 def float_property_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         value = func(*args)
         try:

--- a/sportsreference/mlb/boxscore.py
+++ b/sportsreference/mlb/boxscore.py
@@ -2,6 +2,7 @@ import pandas as pd
 import re
 from pyquery import PyQuery as pq
 from .. import utils
+from ..decorators import float_property_decorator, int_property_decorator
 from .constants import (BOXSCORE_ELEMENT_INDEX,
                         BOXSCORE_SCHEME,
                         BOXSCORE_URL,
@@ -397,16 +398,12 @@ class Boxscore(object):
         """
         return self._venue.replace('Venue: ', '')
 
-    @property
+    @int_property_decorator
     def attendance(self):
         """
         Returns an ``int`` of the game's listed attendance.
         """
-        attendance = self._attendance.replace('Attendance: ', '')
-        try:
-            return int(attendance.replace(',', ''))
-        except ValueError:
-            return 0
+        return self._attendance.replace('Attendance: ', '').replace(',', '')
 
     @property
     def duration(self):
@@ -475,565 +472,553 @@ class Boxscore(object):
             return utils._parse_abbreviation(self._away_name)
         return utils._parse_abbreviation(self._home_name)
 
-    @property
+    @int_property_decorator
     def away_at_bats(self):
         """
         Returns an ``int`` of the number of at bats the away team had.
         """
-        return int(self._away_at_bats)
+        return self._away_at_bats
 
-    @property
+    @int_property_decorator
     def away_runs(self):
         """
         Returns an ``int`` of the number of runs the away team scored.
         """
-        return int(self._away_runs)
+        return self._away_runs
 
-    @property
+    @int_property_decorator
     def away_hits(self):
         """
         Returns an ``int`` of the number of hits the away team had.
         """
-        return int(self._away_hits)
+        return self._away_hits
 
-    @property
+    @int_property_decorator
     def away_rbi(self):
         """
         Returns an ``int`` of the number of runs batted in the away team
         registered.
         """
-        return int(self._away_rbi)
+        return self._away_rbi
 
-    @property
+    @float_property_decorator
     def away_earned_runs(self):
         """
         Returns a ``float`` of the number of runs the away team earned.
         """
-        return float(self._away_earned_runs)
+        return self._away_earned_runs
 
-    @property
+    @int_property_decorator
     def away_bases_on_balls(self):
         """
         Returns an ``int`` of the number of bases the away team registerd as a
         result of balls.
         """
-        return int(self._away_bases_on_balls)
+        return self._away_bases_on_balls
 
-    @property
+    @int_property_decorator
     def away_strikeouts(self):
         """
         Returns an ``int`` of the number of times the away team was struck out.
         """
-        return int(self._away_strikeouts)
+        return self._away_strikeouts
 
-    @property
+    @int_property_decorator
     def away_plate_appearances(self):
         """
         Returns an ``int`` of the number of plate appearances the away team
         made.
         """
-        return int(self._away_plate_appearances)
+        return self._away_plate_appearances
 
-    @property
+    @float_property_decorator
     def away_batting_average(self):
         """
         Returns a ``float`` of the batting average for the away team.
         """
-        return float(self._away_batting_average)
+        return self._away_batting_average
 
-    @property
+    @float_property_decorator
     def away_on_base_percentage(self):
         """
         Returns a ``float`` of the percentage of at bats that result in the
         batter getting on base.
         """
-        return float(self._away_on_base_percentage)
+        return self._away_on_base_percentage
 
-    @property
+    @float_property_decorator
     def away_slugging_percentage(self):
         """
         Returns a ``float`` of the slugging percentage for the away team based
         on the number of bases gained per at-bat with bigger plays getting more
         weight.
         """
-        return float(self._away_slugging_percentage)
+        return self._away_slugging_percentage
 
-    @property
+    @float_property_decorator
     def away_on_base_plus(self):
         """
         Returns a ``float`` of the on base percentage plus the slugging
         percentage. Percentage ranges from 0-1.
         """
-        return float(self._away_on_base_plus)
+        return self._away_on_base_plus
 
-    @property
+    @int_property_decorator
     def away_pitches(self):
         """
         Returns an ``int`` of the number of pitches the away team faced.
         """
-        return int(self._away_pitches)
+        return self._away_pitches
 
-    @property
+    @int_property_decorator
     def away_strikes(self):
         """
         Returns an ``int`` of the number of times a strike was called against
         the away team.
         """
-        return int(self._away_strikes)
+        return self._away_strikes
 
-    @property
+    @float_property_decorator
     def away_win_probability_for_offensive_player(self):
         """
         Returns a ``float`` of the overall influence the away team's offense
         had on the outcome of the game where 0.0 denotes no influence and 1.0
         denotes the offense was solely responsible for the outcome.
         """
-        return float(self._away_win_probability_for_offensive_player)
+        return self._away_win_probability_for_offensive_player
 
-    @property
+    @float_property_decorator
     def away_average_leverage_index(self):
         """
         Returns a ``float`` of the amount of pressure the away team's pitcher
         faced during the game. 1.0 denotes average pressure while numbers less
         than 0 denote lighter pressure.
         """
-        return float(self._away_average_leverage_index)
+        return self._away_average_leverage_index
 
-    @property
+    @float_property_decorator
     def away_win_probability_added(self):
         """
         Returns a ``float`` of the total positive influence the away team's
         offense had on the outcome of the game.
         """
-        return float(self._away_win_probability_added)
+        return self._away_win_probability_added
 
-    @property
+    @float_property_decorator
     def away_win_probability_subtracted(self):
         """
         Returns a ``float`` of the total negative influence the away team's
         offense had on the outcome of the game.
         """
-        return float(self._away_win_probability_subtracted)
+        return self._away_win_probability_subtracted
 
-    @property
+    @float_property_decorator
     def away_base_out_runs_added(self):
         """
         Returns a ``float`` of the number of base out runs added by the away
         team.
         """
-        return float(self._away_base_out_runs_added)
+        return self._away_base_out_runs_added
 
-    @property
+    @int_property_decorator
     def away_putouts(self):
         """
         Returns an ``int`` of the number of putouts the away team registered.
         """
-        return int(self._away_putouts)
+        return self._away_putouts
 
-    @property
+    @int_property_decorator
     def away_assists(self):
         """
         Returns an ``int`` of the number of assists the away team registered.
         """
-        return int(self._away_assists)
+        return self._away_assists
 
-    @property
+    @float_property_decorator
     def away_innings_pitched(self):
         """
         Returns a ``float`` of the number of innings the away team pitched.
         """
-        return float(self._away_innings_pitched)
+        return self._away_innings_pitched
 
-    @property
+    @int_property_decorator
     def away_home_runs(self):
         """
         Returns an ``int`` of the number of times the away team gave up a home
         run.
         """
-        return int(self._away_home_runs)
+        return self._away_home_runs
 
-    @property
+    @int_property_decorator
     def away_strikes_by_contact(self):
         """
         Returns an ``int`` of the number of times the away team struck out a
         batter who made contact with the pitch.
         """
-        return int(self._away_strikes_by_contact)
+        return self._away_strikes_by_contact
 
-    @property
+    @int_property_decorator
     def away_strikes_swinging(self):
         """
         Returns an ``int`` of the number of times the away team struck out a
         batter who was swinging.
         """
-        return int(self._away_strikes_swinging)
+        return self._away_strikes_swinging
 
-    @property
+    @int_property_decorator
     def away_strikes_looking(self):
         """
         Returns an ``int`` of the number of times the away team struck out a
         batter who was looking.
         """
-        return int(self._away_strikes_looking)
+        return self._away_strikes_looking
 
-    @property
+    @int_property_decorator
     def away_grounded_balls(self):
         """
         Returns an ``int`` of the number of grounded balls the away team
         allowed.
         """
-        return int(self._away_grounded_balls)
+        return self._away_grounded_balls
 
-    @property
+    @int_property_decorator
     def away_fly_balls(self):
         """
         Returns an ``int`` of the number of fly balls the away team allowed.
         """
-        return int(self._away_fly_balls)
+        return self._away_fly_balls
 
-    @property
+    @int_property_decorator
     def away_line_drives(self):
         """
         Returns an ``int`` of the number of line drives the away team allowed.
         """
-        return int(self._away_line_drives)
+        return self._away_line_drives
 
-    @property
+    @int_property_decorator
     def away_unknown_bat_type(self):
         """
         Returns an ``int`` of the number of away at bats that were not properly
         tracked and therefore cannot be safely placed in another statistical
         category.
         """
-        return int(self._away_unknown_bat_type)
+        return self._away_unknown_bat_type
 
-    @property
+    @int_property_decorator
     def away_game_score(self):
         """
         Returns an ``int`` of the starting away pitcher's score determine by
         many factors, such as number of runs scored against, number of strikes,
         etc.
         """
-        return int(self._away_game_score)
+        return self._away_game_score
 
-    @property
+    @int_property_decorator
     def away_inherited_runners(self):
         """
         Returns an ``int`` of the number of runners a pitcher inherited when he
         entered the game.
         """
-        try:
-            return int(self._away_inherited_runners)
-        except ValueError:
-            return 0
+        return self._away_inherited_runners
 
-    @property
+    @int_property_decorator
     def away_inherited_score(self):
         """
         Returns an ``int`` of the number of scorers a pitcher inherited when he
         entered the game.
         """
-        try:
-            return int(self._away_inherited_score)
-        except ValueError:
-            return 0
+        return self._away_inherited_score
 
-    @property
+    @float_property_decorator
     def away_win_probability_by_pitcher(self):
         """
         Returns a ``float`` of the amount of influence the away pitcher had on
         the game's result with 0.0 denoting zero influence and 1.0 denoting he
         was solely responsible for the team's win.
         """
-        return float(self._away_win_probability_by_pitcher)
+        return self._away_win_probability_by_pitcher
 
-    @property
+    @float_property_decorator
     def away_base_out_runs_saved(self):
         """
         Returns a ``float`` of the number of runs saved by the away pitcher
         based on the number of players on bases. 0.0 denotes an average value.
         """
-        return float(self._away_base_out_runs_saved)
+        return self._away_base_out_runs_saved
 
-    @property
+    @int_property_decorator
     def home_at_bats(self):
         """
         Returns an ``int`` of the number of at bats the home team had.
         """
-        return int(self._home_at_bats)
+        return self._home_at_bats
 
-    @property
+    @int_property_decorator
     def home_runs(self):
         """
         Returns an ``int`` of the number of runs the home team scored.
         """
-        return int(self._home_runs)
+        return self._home_runs
 
-    @property
+    @int_property_decorator
     def home_hits(self):
         """
         Returns an ``int`` of the number of hits the home team had.
         """
-        return int(self._home_hits)
+        return self._home_hits
 
-    @property
+    @int_property_decorator
     def home_rbi(self):
         """
         Returns an ``int`` of the number of runs batted in the home team
         registered.
         """
-        return int(self._home_rbi)
+        return self._home_rbi
 
-    @property
+    @float_property_decorator
     def home_earned_runs(self):
         """
         Returns a ``float`` of the number of runs the home team earned.
         """
-        return float(self._home_earned_runs)
+        return self._home_earned_runs
 
-    @property
+    @int_property_decorator
     def home_bases_on_balls(self):
         """
         Returns an ``int`` of the number of bases the home team registerd as a
         result of balls.
         """
-        return int(self._home_bases_on_balls)
+        return self._home_bases_on_balls
 
-    @property
+    @int_property_decorator
     def home_strikeouts(self):
         """
         Returns an ``int`` of the number of times the home team was struck out.
         """
-        return int(self._home_strikeouts)
+        return self._home_strikeouts
 
-    @property
+    @int_property_decorator
     def home_plate_appearances(self):
         """
         Returns an ``int`` of the number of plate appearances the home team
         made.
         """
-        return int(self._home_plate_appearances)
+        return self._home_plate_appearances
 
-    @property
+    @float_property_decorator
     def home_batting_average(self):
         """
         Returns a ``float`` of the batting average for the home team.
         """
-        return float(self._home_batting_average)
+        return self._home_batting_average
 
-    @property
+    @float_property_decorator
     def home_on_base_percentage(self):
         """
         Returns a ``float`` of the percentage of at bats that result in the
         batter getting on base.
         """
-        return float(self._home_on_base_percentage)
+        return self._home_on_base_percentage
 
-    @property
+    @float_property_decorator
     def home_slugging_percentage(self):
         """
         Returns a ``float`` of the slugging percentage for the home team based
         on the number of bases gained per at-bat with bigger plays getting more
         weight.
         """
-        return float(self._home_slugging_percentage)
+        return self._home_slugging_percentage
 
-    @property
+    @float_property_decorator
     def home_on_base_plus(self):
         """
         Returns a ``float`` of the on base percentage plus the slugging
         percentage. Percentage ranges from 0-1.
         """
-        return float(self._home_on_base_plus)
+        return self._home_on_base_plus
 
-    @property
+    @int_property_decorator
     def home_pitches(self):
         """
         Returns an ``int`` of the number of pitches the home team faced.
         """
-        return int(self._home_pitches)
+        return self._home_pitches
 
-    @property
+    @int_property_decorator
     def home_strikes(self):
         """
         Returns an ``int`` of the number of times a strike was called against
         the home team.
         """
-        return int(self._home_strikes)
+        return self._home_strikes
 
-    @property
+    @float_property_decorator
     def home_win_probability_for_offensive_player(self):
         """
         Returns a ``float`` of the overall influence the home team's offense
         had on the outcome of the game where 0.0 denotes no influence and 1.0
         denotes the offense was solely responsible for the outcome.
         """
-        return float(self._home_win_probability_for_offensive_player)
+        return self._home_win_probability_for_offensive_player
 
-    @property
+    @float_property_decorator
     def home_average_leverage_index(self):
         """
         Returns a ``float`` of the amount of pressure the home team's pitcher
         faced during the game. 1.0 denotes average pressure while numbers less
         than 0 denote lighter pressure.
         """
-        return float(self._home_average_leverage_index)
+        return self._home_average_leverage_index
 
-    @property
+    @float_property_decorator
     def home_win_probability_added(self):
         """
         Returns a ``float`` of the total positive influence the home team's
         offense had on the outcome of the game.
         """
-        return float(self._home_win_probability_added)
+        return self._home_win_probability_added
 
-    @property
+    @float_property_decorator
     def home_win_probability_subtracted(self):
         """
         Returns a ``float`` of the total negative influence the home team's
         offense had on the outcome of the game.
         """
-        return float(self._home_win_probability_subtracted)
+        return self._home_win_probability_subtracted
 
-    @property
+    @float_property_decorator
     def home_base_out_runs_added(self):
         """
         Returns a ``float`` of the number of base out runs added by the home
         team.
         """
-        return float(self._home_base_out_runs_added)
+        return self._home_base_out_runs_added
 
-    @property
+    @int_property_decorator
     def home_putouts(self):
         """
         Returns an ``int`` of the number of putouts the home team registered.
         """
-        return int(self._home_putouts)
+        return self._home_putouts
 
-    @property
+    @int_property_decorator
     def home_assists(self):
         """
         Returns an ``int`` of the number of assists the home team registered.
         """
-        return int(self._home_assists)
+        return self._home_assists
 
-    @property
+    @float_property_decorator
     def home_innings_pitched(self):
         """
         Returns a ``float`` of the number of innings the home team pitched.
         """
-        return float(self._home_innings_pitched)
+        return self._home_innings_pitched
 
-    @property
+    @int_property_decorator
     def home_home_runs(self):
         """
         Returns an ``int`` of the number of times the home team gave up a home
         run.
         """
-        return int(self._home_home_runs)
+        return self._home_home_runs
 
-    @property
+    @int_property_decorator
     def home_strikes_by_contact(self):
         """
         Returns an ``int`` of the number of times the home team struck out a
         batter who made contact with the pitch.
         """
-        return int(self._home_strikes_by_contact)
+        return self._home_strikes_by_contact
 
-    @property
+    @int_property_decorator
     def home_strikes_swinging(self):
         """
         Returns an ``int`` of the number of times the home team struck out a
         batter who was swinging.
         """
-        return int(self._home_strikes_swinging)
+        return self._home_strikes_swinging
 
-    @property
+    @int_property_decorator
     def home_strikes_looking(self):
         """
         Returns an ``int`` of the number of times the home team struck out a
         batter who was looking.
         """
-        return int(self._home_strikes_looking)
+        return self._home_strikes_looking
 
-    @property
+    @int_property_decorator
     def home_grounded_balls(self):
         """
         Returns an ``int`` of the number of grounded balls the home team
         allowed.
         """
-        return int(self._home_grounded_balls)
+        return self._home_grounded_balls
 
-    @property
+    @int_property_decorator
     def home_fly_balls(self):
         """
         Returns an ``int`` of the number of fly balls the home team allowed.
         """
-        return int(self._home_fly_balls)
+        return self._home_fly_balls
 
-    @property
+    @int_property_decorator
     def home_line_drives(self):
         """
         Returns an ``int`` of the number of line drives the home team allowed.
         """
-        return int(self._home_line_drives)
+        return self._home_line_drives
 
-    @property
+    @int_property_decorator
     def home_unknown_bat_type(self):
         """
         Returns an ``int`` of the number of home at bats that were not properly
         tracked and therefore cannot be safely placed in another statistical
         category.
         """
-        return int(self._home_unknown_bat_type)
+        return self._home_unknown_bat_type
 
-    @property
+    @int_property_decorator
     def home_game_score(self):
         """
         Returns an ``int`` of the starting home pitcher's score determine by
         many factors, such as number of runs scored against, number of strikes,
         etc.
         """
-        return int(self._home_game_score)
+        return self._home_game_score
 
-    @property
+    @int_property_decorator
     def home_inherited_runners(self):
         """
         Returns an ``int`` of the number of runners a pitcher inherited when he
         entered the game.
         """
-        try:
-            return int(self._home_inherited_runners)
-        except ValueError:
-            return 0
+        return self._home_inherited_runners
 
-    @property
+    @int_property_decorator
     def home_inherited_score(self):
         """
         Returns an ``int`` of the number of scorers a pitcher inherited when he
         entered the game.
         """
-        try:
-            return int(self._home_inherited_score)
-        except ValueError:
-            return 0
+        return self._home_inherited_score
 
-    @property
+    @float_property_decorator
     def home_win_probability_by_pitcher(self):
         """
         Returns a ``float`` of the amount of influence the home pitcher had on
         the game's result with 0.0 denoting zero influence and 1.0 denoting he
         was solely responsible for the team's win.
         """
-        return float(self._home_win_probability_by_pitcher)
+        return self._home_win_probability_by_pitcher
 
-    @property
+    @float_property_decorator
     def home_base_out_runs_saved(self):
         """
         Returns a ``float`` of the number of runs saved by the home pitcher
         based on the number of players on bases. 0.0 denotes an average value.
         """
-        return float(self._home_base_out_runs_saved)
+        return self._home_base_out_runs_saved
 
 
 class Boxscores:

--- a/sportsreference/mlb/constants.py
+++ b/sportsreference/mlb/constants.py
@@ -84,6 +84,31 @@ PARSING_SCHEME = {
     'opposing_runners_left_on_base': 'td[data-stat="LOB"]:first'
 }
 
+TEAM_ELEMENT = {
+    'home_wins': 0,
+    'home_losses': 1,
+    'away_wins': 0,
+    'away_losses': 1,
+    'extra_inning_wins': 0,
+    'extra_inning_losses': 1,
+    'single_run_wins': 0,
+    'single_run_losses': 1,
+    'wins_vs_right_handed_pitchers': 0,
+    'losses_vs_right_handed_pitchers': 1,
+    'wins_vs_left_handed_pitchers': 0,
+    'losses_vs_left_handed_pitchers': 1,
+    'wins_vs_teams_over_500': 0,
+    'losses_vs_teams_over_500': 1,
+    'wins_vs_teams_under_500': 0,
+    'losses_vs_teams_under_500': 1,
+    'wins_last_ten_games': 0,
+    'losses_last_ten_games': 1,
+    'wins_last_twenty_games': 0,
+    'losses_last_twenty_games': 1,
+    'wins_last_thirty_games': 0,
+    'losses_last_thirty_games': 1
+}
+
 SCHEDULE_SCHEME = {
     'game': 'th[data-stat="team_game"]:first',
     'date': 'td[data-stat="date_game"]:first',

--- a/sportsreference/mlb/schedule.py
+++ b/sportsreference/mlb/schedule.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+from ..decorators import int_property_decorator
 from .constants import (DAY,
                         NIGHT,
                         SCHEDULE_SCHEME,
@@ -151,13 +152,13 @@ class Game(object):
             return None
         return self.boxscore.dataframe
 
-    @property
+    @int_property_decorator
     def game(self):
         """
         Returns an ``int`` of the game in the season, where 1 is the first game
         of the season.
         """
-        return int(self._game)
+        return self._game
 
     @property
     def date(self):
@@ -226,29 +227,29 @@ class Game(object):
             return WIN
         return LOSS
 
-    @property
+    @int_property_decorator
     def runs_scored(self):
         """
         Returns an ``int`` of the total number of runs that were scored by the
         team.
         """
-        return int(self._runs_scored)
+        return self._runs_scored
 
-    @property
+    @int_property_decorator
     def runs_allowed(self):
         """
         Returns an ``int`` of the total number of runs that the team allowed.
         """
-        return int(self._runs_allowed)
+        return self._runs_allowed
 
-    @property
+    @int_property_decorator
     def innings(self):
         """
         Returns an ``int`` of the total number of innings that were played.
         """
         if not self._innings:
             return 9
-        return int(self._innings)
+        return self._innings
 
     @property
     def record(self):
@@ -257,13 +258,13 @@ class Game(object):
         """
         return self._record
 
-    @property
+    @int_property_decorator
     def rank(self):
         """
         Returns an ``int`` of the team's rank in the league with 1 being the
         best team.
         """
-        return int(self._rank)
+        return self._rank
 
     @property
     def games_behind(self):
@@ -274,10 +275,16 @@ class Game(object):
         """
         if 'up' in self._games_behind.lower():
             games_behind = re.sub('up *', '', self._games_behind.lower())
-            return float(games_behind) * -1.0
+            try:
+                return float(games_behind) * -1.0
+            except ValueError:
+                return None
         if 'tied' in self._games_behind.lower():
             return 0.0
-        return float(self._games_behind)
+        try:
+            return float(self._games_behind)
+        except ValueError:
+            return None
 
     @property
     def winner(self):
@@ -320,15 +327,12 @@ class Game(object):
             return NIGHT
         return DAY
 
-    @property
+    @int_property_decorator
     def attendance(self):
         """
         Returns an ``int`` of the total listed attendance for the game.
         """
-        try:
-            return int(self._attendance.replace(',', ''))
-        except ValueError:
-            return 0
+        return self._attendance.replace(',', '')
 
     @property
     def streak(self):

--- a/sportsreference/mlb/schedule.py
+++ b/sportsreference/mlb/schedule.py
@@ -475,6 +475,8 @@ class Schedule(object):
             if game._runs_scored is None and game._runs_allowed is None:
                 continue
             frames.append(game.dataframe)
+        if frames == []:
+            return None
         return pd.concat(frames)
 
     @property
@@ -488,5 +490,9 @@ class Schedule(object):
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe_extended)
+            df = game.dataframe_extended
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)

--- a/sportsreference/mlb/teams.py
+++ b/sportsreference/mlb/teams.py
@@ -5,6 +5,7 @@ from .constants import (ELEMENT_INDEX,
                         STANDINGS_URL,
                         TEAM_ELEMENT,
                         TEAM_STATS_URL)
+from functools import wraps
 from pyquery import PyQuery as pq
 from .. import utils
 from ..decorators import float_property_decorator, int_property_decorator
@@ -13,6 +14,7 @@ from .schedule import Schedule
 
 def mlb_int_property_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         value = func(*args)
         # Equivalent to the calling property's method name

--- a/sportsreference/mlb/teams.py
+++ b/sportsreference/mlb/teams.py
@@ -3,13 +3,32 @@ import re
 from .constants import (ELEMENT_INDEX,
                         PARSING_SCHEME,
                         STANDINGS_URL,
+                        TEAM_ELEMENT,
                         TEAM_STATS_URL)
 from pyquery import PyQuery as pq
 from .. import utils
+from ..decorators import float_property_decorator, int_property_decorator
 from .schedule import Schedule
 
 
-class Team:
+def mlb_int_property_decorator(func):
+    @property
+    def wrapper(*args):
+        value = func(*args)
+        # Equivalent to the calling property's method name
+        field = func.__name__
+        try:
+            record = value.split('-')
+        except AttributeError:
+            return None
+        try:
+            return int(record[TEAM_ELEMENT[field]])
+        except (TypeError, ValueError, IndexError):
+            return None
+    return wrapper
+
+
+class Team(object):
     """
     An object containing all of a team's season information.
 
@@ -305,12 +324,12 @@ class Team:
         }
         return pd.DataFrame([fields_to_include], index=[self._abbreviation])
 
-    @property
+    @int_property_decorator
     def rank(self):
         """
         Returns an ``int`` of the team's rank based on their win percentage.
         """
-        return int(self._rank)
+        return self._rank
 
     @property
     def abbreviation(self):
@@ -343,37 +362,37 @@ class Team:
         """
         return self._league
 
-    @property
+    @int_property_decorator
     def games(self):
         """
         Returns an ``int`` of the number of games the team has played during
         the season.
         """
-        return int(self._games)
+        return self._games
 
-    @property
+    @int_property_decorator
     def wins(self):
         """
         Returns an ``int`` of the total number of games the team won during the
         season.
         """
-        return int(self._wins)
+        return self._wins
 
-    @property
+    @int_property_decorator
     def losses(self):
         """
         Returns an ``int`` of the total number of games the team lost during
         the season.
         """
-        return int(self._losses)
+        return self._losses
 
-    @property
+    @float_property_decorator
     def win_percentage(self):
         """
         Returns a ``float`` of the number of wins divided by the number of
         games played during the season. Percentage ranges from 0-1.
         """
-        return float(self._win_percentage)
+        return self._win_percentage
 
     @property
     def streak(self):
@@ -383,47 +402,47 @@ class Team:
         """
         return self._streak
 
-    @property
+    @float_property_decorator
     def runs(self):
         """
         Returns a ``float`` of the average number of runs scored per game by
         the team.
         """
-        return float(self._runs)
+        return self._runs
 
-    @property
+    @float_property_decorator
     def runs_against(self):
         """
         Returns a ``float`` of the average number of runs scored per game by
         the opponent.
         """
-        return float(self._runs_against)
+        return self._runs_against
 
-    @property
+    @float_property_decorator
     def run_difference(self):
         """
         Returns a ``float`` of the difference between the number of runs scored
         and the number of runs given up per game. Positive numbers indicate
         the team scores more per game than they are scored on.
         """
-        return float(self._run_difference)
+        return self._run_difference
 
-    @property
+    @float_property_decorator
     def strength_of_schedule(self):
         """
         Returns a ``float`` denoting a team's strength of schedule, based on
         runs scores and conceded. Higher values result in more challenging
         schedules while 0.0 is an average schedule.
         """
-        return float(self._strength_of_schedule)
+        return self._strength_of_schedule
 
-    @property
+    @float_property_decorator
     def simple_rating_system(self):
         """
         Returns a ``float`` of the average number of runs per game a team
         scores compared to average.
         """
-        return float(self._simple_rating_system)
+        return self._simple_rating_system
 
     @property
     def pythagorean_win_loss(self):
@@ -433,13 +452,13 @@ class Team:
         """
         return self._pythagorean_win_loss
 
-    @property
+    @int_property_decorator
     def luck(self):
         """
-        Returns an ``int``eger of the difference between the current wins and
+        Returns an ``int`` of the difference between the current wins and
         losses compared to the pythagorean wins and losses.
         """
-        return int(self._luck)
+        return self._luck
 
     @property
     def interleague_record(self):
@@ -457,19 +476,19 @@ class Team:
         """
         return self._home_record
 
-    @property
+    @mlb_int_property_decorator
     def home_wins(self):
         """
         Returns an ``int`` of the number of wins at home during the season.
         """
-        return int(self._home_record.split('-')[0])
+        return self._home_record
 
-    @property
+    @mlb_int_property_decorator
     def home_losses(self):
         """
         Returns an ``int`` of the number of losses at home during the season.
         """
-        return int(self._home_record.split('-')[1])
+        return self._home_record
 
     @property
     def away_record(self):
@@ -479,19 +498,19 @@ class Team:
         """
         return self._away_record
 
-    @property
+    @mlb_int_property_decorator
     def away_wins(self):
         """
         Returns an ``int`` of the number of away wins during the season.
         """
-        return int(self._away_record.split('-')[0])
+        return self._away_record
 
-    @property
+    @mlb_int_property_decorator
     def away_losses(self):
         """
         Returns an ``int`` of the number of away losses during the season.
         """
-        return int(self._away_record.split('-')[1])
+        return self._away_record
 
     @property
     def extra_inning_record(self):
@@ -501,21 +520,21 @@ class Team:
         """
         return self._extra_inning_record
 
-    @property
+    @mlb_int_property_decorator
     def extra_inning_wins(self):
         """
         Returns an ``int`` of the number of wins the team has when the game has
         gone to extra innings.
         """
-        return int(self._extra_inning_record.split('-')[0])
+        return self._extra_inning_record
 
-    @property
+    @mlb_int_property_decorator
     def extra_inning_losses(self):
         """
         Returns an ``int`` of the number of losses the team has when the game
         has gone to extra innings.
         """
-        return int(self._extra_inning_record.split('-')[1])
+        return self._extra_inning_record
 
     @property
     def single_run_record(self):
@@ -525,21 +544,21 @@ class Team:
         """
         return self._single_run_record
 
-    @property
+    @mlb_int_property_decorator
     def single_run_wins(self):
         """
         Returns an ``int`` of the number of wins the team has when only one run
         is scored.
         """
-        return int(self._single_run_record.split('-')[0])
+        return self._single_run_record
 
-    @property
+    @mlb_int_property_decorator
     def single_run_losses(self):
         """
         Returns an ``int`` of the number of losses the team has when only one
         run is scored.
         """
-        return int(self._single_run_record.split('-')[1])
+        return self._single_run_record
 
     @property
     def record_vs_right_handed_pitchers(self):
@@ -550,20 +569,20 @@ class Team:
         """
         return self._record_vs_right_handed_pitchers
 
-    @property
+    @mlb_int_property_decorator
     def wins_vs_right_handed_pitchers(self):
         """
         Returns an ``int`` of the number of wins against right-handed pitchers.
         """
-        return int(self._record_vs_right_handed_pitchers.split('-')[0])
+        return self._record_vs_right_handed_pitchers
 
-    @property
+    @mlb_int_property_decorator
     def losses_vs_right_handed_pitchers(self):
         """
         Returns an ``int`` of the number of losses against right-handed
         pitchers.
         """
-        return int(self._record_vs_right_handed_pitchers.split('-')[1])
+        return self._record_vs_right_handed_pitchers
 
     @property
     def record_vs_left_handed_pitchers(self):
@@ -573,19 +592,19 @@ class Team:
         """
         return self._record_vs_left_handed_pitchers
 
-    @property
+    @mlb_int_property_decorator
     def wins_vs_left_handed_pitchers(self):
         """
         Returns an ``int`` of number of wins against left-handed pitchers.
         """
-        return int(self._record_vs_left_handed_pitchers.split('-')[0])
+        return self._record_vs_left_handed_pitchers
 
-    @property
+    @mlb_int_property_decorator
     def losses_vs_left_handed_pitchers(self):
         """
         Returns an ``int`` of number of losses against left-handed pitchers.
         """
-        return int(self._record_vs_left_handed_pitchers.split('-')[1])
+        return self._record_vs_left_handed_pitchers
 
     @property
     def record_vs_teams_over_500(self):
@@ -595,19 +614,19 @@ class Team:
         """
         return self._record_vs_teams_over_500
 
-    @property
+    @mlb_int_property_decorator
     def wins_vs_teams_over_500(self):
         """
         Returns an ``int`` of the number of wins against teams over 500.
         """
-        return int(self._record_vs_teams_over_500.split('-')[0])
+        return self._record_vs_teams_over_500
 
-    @property
+    @mlb_int_property_decorator
     def losses_vs_teams_over_500(self):
         """
         Returns an ``int`` of the number of losses against teams over 500.
         """
-        return int(self._record_vs_teams_over_500.split('-')[1])
+        return self._record_vs_teams_over_500
 
     @property
     def record_vs_teams_under_500(self):
@@ -617,19 +636,19 @@ class Team:
         """
         return self._record_vs_teams_under_500
 
-    @property
+    @mlb_int_property_decorator
     def wins_vs_teams_under_500(self):
         """
         Returns an ``int`` of the number of wins against teams under 500.
         """
-        return int(self._record_vs_teams_under_500.split('-')[0])
+        return self._record_vs_teams_under_500
 
-    @property
+    @mlb_int_property_decorator
     def losses_vs_teams_under_500(self):
         """
         Returns an ``int`` of the number of losses against teams under 500.
         """
-        return int(self._record_vs_teams_under_500.split('-')[1])
+        return self._record_vs_teams_under_500
 
     @property
     def last_ten_games_record(self):
@@ -639,25 +658,19 @@ class Team:
         """
         return self._last_ten_games_record
 
-    @property
+    @mlb_int_property_decorator
     def wins_last_ten_games(self):
         """
         Returns an ``int`` of the number of wins in the last 10 games.
         """
-        try:
-            return int(self._last_ten_games_record.split('-')[0])
-        except AttributeError:
-            return None
+        return self._last_ten_games_record
 
-    @property
+    @mlb_int_property_decorator
     def losses_last_ten_games(self):
         """
         Returns an ``int`` of the number of losses in the last 10 games.
         """
-        try:
-            return int(self._last_ten_games_record.split('-')[1])
-        except AttributeError:
-            return None
+        return self._last_ten_games_record
 
     @property
     def last_twenty_games_record(self):
@@ -667,25 +680,19 @@ class Team:
         """
         return self._last_twenty_games_record
 
-    @property
+    @mlb_int_property_decorator
     def wins_last_twenty_games(self):
         """
         Returns an ``int`` of the number of wins in the last 20 games.
         """
-        try:
-            return int(self._last_twenty_games_record.split('-')[0])
-        except AttributeError:
-            return None
+        return self._last_twenty_games_record
 
-    @property
+    @mlb_int_property_decorator
     def losses_last_twenty_games(self):
         """
         Returns an ``int`` of the number of losses in the last 20 games.
         """
-        try:
-            return int(self._last_twenty_games_record.split('-')[1])
-        except AttributeError:
-            return None
+        return self._last_twenty_games_record
 
     @property
     def last_thirty_games_record(self):
@@ -695,438 +702,432 @@ class Team:
         """
         return self._last_thirty_games_record
 
-    @property
+    @mlb_int_property_decorator
     def wins_last_thirty_games(self):
         """
         Returns an ``int`` of the number of wins in the last 30 games.
         """
-        try:
-            return int(self._last_thirty_games_record.split('-')[0])
-        except AttributeError:
-            return None
+        return self._last_thirty_games_record
 
-    @property
+    @mlb_int_property_decorator
     def losses_last_thirty_games(self):
         """
         Returns an ``int`` of the number of losses in the last 30 games.
         """
-        try:
-            return int(self._last_thirty_games_record.split('-')[1])
-        except AttributeError:
-            return None
+        return self._last_thirty_games_record
 
-    @property
+    @int_property_decorator
     def number_players_used(self):
         """
         Returns an ``int`` of the number of different players used during the
         season.
         """
-        return int(self._number_players_used)
+        return self._number_players_used
 
-    @property
+    @float_property_decorator
     def average_batter_age(self):
         """
         Returns a ``float`` of the average batter age weighted by their number
         of at bats plus the number of games participated in.
         """
-        return float(self._average_batter_age)
+        return self._average_batter_age
 
-    @property
+    @int_property_decorator
     def plate_appearances(self):
         """
         Returns an ``int`` of the total number of plate appearances for the
         team.
         """
-        return int(self._plate_appearances)
+        return self._plate_appearances
 
-    @property
+    @int_property_decorator
     def at_bats(self):
         """
         Returns an ``int`` of the total number of at bats for the team.
         """
-        return int(self._at_bats)
+        return self._at_bats
 
-    @property
+    @int_property_decorator
     def total_runs(self):
         """
         Returns an ``int`` of the total number of runs scored during the
         season.
         """
-        return int(self._total_runs)
+        return self._total_runs
 
-    @property
+    @int_property_decorator
     def hits(self):
         """
         Returns an ``int`` of the total number of hits during the season.
         """
-        return int(self._hits)
+        return self._hits
 
-    @property
+    @int_property_decorator
     def doubles(self):
         """
         Returns an ``int`` of the total number of doubles hit by the team.
         """
-        return int(self._doubles)
+        return self._doubles
 
-    @property
+    @int_property_decorator
     def triples(self):
         """
         Returns an ``int`` of the total number of tripes hit by the team.
         """
-        return int(self._triples)
+        return self._triples
 
-    @property
+    @int_property_decorator
     def home_runs(self):
         """
         Returns an ``int`` of the total number of home runs hit by the team.
         """
-        return int(self._home_runs)
+        return self._home_runs
 
-    @property
+    @int_property_decorator
     def runs_batted_in(self):
         """
         Returns an ``int`` of the total number of runs batted in by the team.
         """
-        return int(self._runs_batted_in)
+        return self._runs_batted_in
 
-    @property
+    @int_property_decorator
     def stolen_bases(self):
         """
         Returns an ``int`` of the total number of bases stolen by the team.
         """
-        return int(self._stolen_bases)
+        return self._stolen_bases
 
-    @property
+    @int_property_decorator
     def times_caught_stealing(self):
         """
         Returns an ``int`` of the number of times a player was caught stealing.
         """
-        return int(self._times_caught_stealing)
+        return self._times_caught_stealing
 
-    @property
+    @int_property_decorator
     def bases_on_balls(self):
         """
         Returns an ``int`` of the number of bases on walks.
         """
-        return int(self._bases_on_balls)
+        return self._bases_on_balls
 
-    @property
+    @int_property_decorator
     def times_struck_out(self):
         """
         Returns an ``int`` of the total number of times the team struck out.
         """
-        return int(self._times_struck_out)
+        return self._times_struck_out
 
-    @property
+    @float_property_decorator
     def batting_average(self):
         """
         Returns a ``float`` of the batting average for the team. Percentage
         ranges from 0-1.
         """
-        return float(self._batting_average)
+        return self._batting_average
 
-    @property
+    @float_property_decorator
     def on_base_percentage(self):
         """
         Returns a ``float`` of the percentage of at bats that result in a
         player taking a base. Percentage ranges from 0-1.
         """
-        return float(self._on_base_percentage)
+        return self._on_base_percentage
 
-    @property
+    @float_property_decorator
     def slugging_percentage(self):
         """
         Returns a ``float`` of the ratio of total bases gained per at bat.
         """
-        return float(self._slugging_percentage)
+        return self._slugging_percentage
 
-    @property
+    @float_property_decorator
     def on_base_plus_slugging_percentage(self):
         """
         Returns a ``float`` of the sum of the on base percentage plus the
         slugging percentage.
         """
-        return float(self._on_base_plus_slugging_percentage)
+        return self._on_base_plus_slugging_percentage
 
-    @property
+    @int_property_decorator
     def on_base_plus_slugging_percentage_plus(self):
         """
         Returns an ``int`` of the on base percentage plus the slugging
         percentage, adjusted to the team's home ballpark.
         """
-        return int(self._on_base_plus_slugging_percentage_plus)
+        return self._on_base_plus_slugging_percentage_plus
 
-    @property
+    @int_property_decorator
     def total_bases(self):
         """
         Returns an ``int`` of the total number of bases a team has gained
         during the season.
         """
-        return int(self._total_bases)
+        return self._total_bases
 
-    @property
+    @int_property_decorator
     def grounded_into_double_plays(self):
         """
         Returns an ``int`` of the total number double plays grounded into by
         the team.
         """
-        return int(self._grounded_into_double_plays)
+        return self._grounded_into_double_plays
 
-    @property
+    @int_property_decorator
     def times_hit_by_pitch(self):
         """
         Returns an ``int`` of the total number of times a batter was hit by an
         opponent's pitch.
         """
-        return int(self._times_hit_by_pitch)
+        return self._times_hit_by_pitch
 
-    @property
+    @int_property_decorator
     def sacrifice_hits(self):
         """
         Returns an ``int`` of the total number of sacrifice hits the team made
         during the season.
         """
-        return int(self._sacrifice_hits)
+        return self._sacrifice_hits
 
-    @property
+    @int_property_decorator
     def sacrifice_flies(self):
         """
         Returns an ``int`` of the total number of sacrifice flies the team made
         during the season.
         """
-        return int(self._sacrifice_flies)
+        return self._sacrifice_flies
 
-    @property
+    @int_property_decorator
     def intentional_bases_on_balls(self):
         """
         Returns an ``int`` of the total number of times a player took a base
         from an intentional walk.
         """
-        return int(self._intentional_bases_on_balls)
+        return self._intentional_bases_on_balls
 
-    @property
+    @int_property_decorator
     def runners_left_on_base(self):
         """
         Returns an ``int`` of the total number of runners left on base at the
         end of an inning.
         """
-        return int(self._runners_left_on_base)
+        return self._runners_left_on_base
 
-    @property
+    @int_property_decorator
     def number_of_pitchers(self):
         """
         Returns an ``int`` of the total number of pitchers used during a
         season.
         """
-        return int(self._number_of_pitchers)
+        return self._number_of_pitchers
 
-    @property
+    @float_property_decorator
     def average_pitcher_age(self):
         """
         Returns a ``float`` of the average pitcher age weighted by the number
         of games started, followed by the number of games played and saves.
         """
-        return float(self._average_pitcher_age)
+        return self._average_pitcher_age
 
-    @property
+    @float_property_decorator
     def runs_allowed_per_game(self):
         """
         Returns a ``float`` of the average number of runs a team has allowed
         per game.
         """
-        return float(self._runs_allowed_per_game)
+        return self._runs_allowed_per_game
 
-    @property
+    @float_property_decorator
     def earned_runs_against(self):
         """
         Returns a ``float`` of the average number of earned runs against for a
         team.
         """
-        return float(self._earned_runs_against)
+        return self._earned_runs_against
 
-    @property
+    @int_property_decorator
     def games_finished(self):
         """
         Returns an ``int`` of the number of games finished which is equivalent
         to the number of games played minus the number of complete games during
         the season.
         """
-        return int(self._games_finished)
+        return self._games_finished
 
-    @property
+    @int_property_decorator
     def complete_games(self):
         """
         Returns an ``int`` of the total number of complete games a team has
         accumulated during the season.
         """
-        return int(self._complete_games)
+        return self._complete_games
 
-    @property
+    @int_property_decorator
     def shutouts(self):
         """
         Returns an ``int`` of the total number of shutouts a team has
         accumulated during the season.
         """
-        return int(self._shutouts)
+        return self._shutouts
 
-    @property
+    @int_property_decorator
     def complete_game_shutouts(self):
         """
         Returns an ``int`` of the total number of complete games where the
         opponent scored zero runs.
         """
-        return int(self._complete_game_shutouts)
+        return self._complete_game_shutouts
 
-    @property
+    @int_property_decorator
     def saves(self):
         """
         Returns an ``int`` of the total number of saves a team has accumulated
         during the season.
         """
-        return int(self._saves)
+        return self._saves
 
-    @property
+    @float_property_decorator
     def innings_pitched(self):
         """
         Returns a ``float`` of the total number of innings pitched by a team
         during the season.
         """
-        return float(self._innings_pitched)
+        return self._innings_pitched
 
-    @property
+    @int_property_decorator
     def hits_allowed(self):
         """
         Returns an ``int`` of the total number of hits allowed during the
         season.
         """
-        return int(self._hits_allowed)
+        return self._hits_allowed
 
-    @property
+    @int_property_decorator
     def home_runs_against(self):
         """
         Returns an ``int`` of the total number of home runs given up during the
         season.
         """
-        return int(self._home_runs_against)
+        return self._home_runs_against
 
-    @property
+    @int_property_decorator
     def bases_on_walks_given(self):
         """
         Returns an ``int`` of the total number of bases from walks given up by
         a team during the season.
         """
-        return int(self._bases_on_walks_given)
+        return self._bases_on_walks_given
 
-    @property
+    @int_property_decorator
     def strikeouts(self):
         """
         Returns an ``int`` of the total number of times a team has struck out
         an opponent.
         """
-        return int(self._strikeouts)
+        return self._strikeouts
 
-    @property
+    @int_property_decorator
     def hit_pitcher(self):
         """
         Returns an ``int`` of the total number of times a pitcher has hit an
         opposing batter.
         """
-        return int(self._hit_pitcher)
+        return self._hit_pitcher
 
-    @property
+    @int_property_decorator
     def balks(self):
         """
         Returns an ``int`` of the total number of times a pitcher has balked.
         """
-        return int(self._balks)
+        return self._balks
 
-    @property
+    @int_property_decorator
     def wild_pitches(self):
         """
         Returns an ``int`` of the total number of wild pitches thrown by a team
         during a season.
         """
-        return int(self._wild_pitches)
+        return self._wild_pitches
 
-    @property
+    @int_property_decorator
     def batters_faced(self):
         """
         Returns an ``int`` of the total number of batters all pitchers have
         faced during a season.
         """
-        return int(self._batters_faced)
+        return self._batters_faced
 
-    @property
+    @int_property_decorator
     def earned_runs_against_plus(self):
         """
         Returns an ``int`` of the team's average earned runs against, adjusted
         for the home ballpark.
         """
-        return int(self._earned_runs_against_plus)
+        return self._earned_runs_against_plus
 
-    @property
+    @float_property_decorator
     def fielding_independent_pitching(self):
         """
         Returns a ``float`` of the team's effectiveness at preventing home
         runs, walks, batters being hit by pitches, and strikeouts.
         """
-        return float(self._fielding_independent_pitching)
+        return self._fielding_independent_pitching
 
-    @property
+    @float_property_decorator
     def whip(self):
         """
         Returns a ``float`` of the average number of walks plus hits by the
         opponent per inning.
         """
-        return float(self._whip)
+        return self._whip
 
-    @property
+    @float_property_decorator
     def hits_per_nine_innings(self):
         """
         Returns a ``float`` of the average number of hits per nine innings by
         the opponent.
         """
-        return float(self._hits_per_nine_innings)
+        return self._hits_per_nine_innings
 
-    @property
+    @float_property_decorator
     def home_runs_per_nine_innings(self):
         """
         Returns a ``float`` of the average number of home runs per nine innings
         by the opponent.
         """
-        return float(self._home_runs_per_nine_innings)
+        return self._home_runs_per_nine_innings
 
-    @property
+    @float_property_decorator
     def bases_on_walks_given_per_nine_innings(self):
         """
         Returns a ``float`` of the average number of walks conceded per nine
         innings.
         """
-        return float(self._bases_on_walks_given_per_nine_innings)
+        return self._bases_on_walks_given_per_nine_innings
 
-    @property
+    @float_property_decorator
     def strikeouts_per_nine_innings(self):
         """
         Returns a ``float`` of the average number of strikeouts a team throws
         per nine innings.
         """
-        return float(self._strikeouts_per_nine_innings)
+        return self._strikeouts_per_nine_innings
 
-    @property
+    @float_property_decorator
     def strikeouts_per_base_on_balls(self):
         """
         Returns a ``float`` of the average number of strikeouts per walk thrown
         by a team.
         """
-        return float(self._strikeouts_per_base_on_balls)
+        return self._strikeouts_per_base_on_balls
 
-    @property
+    @int_property_decorator
     def opposing_runners_left_on_base(self):
         """
         Returns an ``int`` of the total number of opponents a team has left on
         bases at the end of an inning.
         """
-        return int(self._opposing_runners_left_on_base)
+        return self._opposing_runners_left_on_base
 
 
 class Teams:

--- a/sportsreference/nba/boxscore.py
+++ b/sportsreference/nba/boxscore.py
@@ -2,6 +2,7 @@ import pandas as pd
 import re
 from pyquery import PyQuery as pq
 from .. import utils
+from ..decorators import float_property_decorator, int_property_decorator
 from .constants import (BOXSCORE_ELEMENT_INDEX,
                         BOXSCORE_SCHEME,
                         BOXSCORE_URL,
@@ -413,15 +414,15 @@ class Boxscore(object):
             return utils._parse_abbreviation(self._away_name)
         return utils._parse_abbreviation(self._home_name)
 
-    @property
+    @float_property_decorator
     def pace(self):
         """
         Returns a ``float`` of the game's overall pace, measured by the number
         of possessions per 40 minutes.
         """
-        return float(self._pace)
+        return self._pace
 
-    @property
+    @int_property_decorator
     def away_wins(self):
         """
         Returns an ``int`` of the number of games the team has won after the
@@ -429,11 +430,11 @@ class Boxscore(object):
         """
         try:
             wins, losses = re.findall('\d+', self._away_record)
-            return int(wins)
+            return wins
         except ValueError:
             return 0
 
-    @property
+    @int_property_decorator
     def away_losses(self):
         """
         Returns an ``int`` of the number of games the team has lost after the
@@ -441,69 +442,69 @@ class Boxscore(object):
         """
         try:
             wins, losses = re.findall('\d+', self._away_record)
-            return int(losses)
+            return losses
         except ValueError:
             return 0
 
-    @property
+    @int_property_decorator
     def away_minutes_played(self):
         """
         Returns an ``int`` of the total number of minutes the team played
         during the game.
         """
-        return int(self._away_minutes_played)
+        return self._away_minutes_played
 
-    @property
+    @int_property_decorator
     def away_field_goals(self):
         """
         Returns an ``int`` of the total number of field goals made by the away
         team.
         """
-        return int(self._away_field_goals)
+        return self._away_field_goals
 
-    @property
+    @int_property_decorator
     def away_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goal attempts by the
         away team.
         """
-        return int(self._away_field_goal_attempts)
+        return self._away_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def away_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of field goals made divided by the
         total number of field goal attempts by the away team. Percentage ranges
         from 0-1.
         """
-        return float(self._away_field_goal_percentage)
+        return self._away_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def away_three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals made
         by the away team.
         """
-        return int(self._away_three_point_field_goals)
+        return self._away_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def away_three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goal
         attempts by the away team.
         """
-        return int(self._away_three_point_field_goal_attempts)
+        return self._away_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def away_three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of three point field goals made
         divided by the number of three point field goal attempts by the away
         team. Percentage ranges from 0-1.
         """
-        return float(self._away_three_point_field_goal_percentage)
+        return self._away_three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def away_two_point_field_goals(self):
         """
         Returns an ``int`` of the total number of two point field goals made
@@ -511,7 +512,7 @@ class Boxscore(object):
         """
         return self.away_field_goals - self.away_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def away_two_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of two point field goal attempts
@@ -520,7 +521,7 @@ class Boxscore(object):
         return self.away_field_goal_attempts - \
             self.away_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def away_two_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of two point field goals made divided
@@ -531,202 +532,202 @@ class Boxscore(object):
             float(self.away_two_point_field_goal_attempts)
         return round(float(result), 3)
 
-    @property
+    @int_property_decorator
     def away_free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made by the away
         team.
         """
-        return int(self._away_free_throws)
+        return self._away_free_throws
 
-    @property
+    @int_property_decorator
     def away_free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts by the
         away team.
         """
-        return int(self._away_free_throw_attempts)
+        return self._away_free_throw_attempts
 
-    @property
+    @float_property_decorator
     def away_free_throw_percentage(self):
         """
         Returns a ``float`` of the number of free throws made divided by the
         number of free throw attempts  by the away team.
         """
-        return float(self._away_free_throw_percentage)
+        return self._away_free_throw_percentage
 
-    @property
+    @int_property_decorator
     def away_offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds by the
         away team.
         """
-        return int(self._away_offensive_rebounds)
+        return self._away_offensive_rebounds
 
-    @property
+    @int_property_decorator
     def away_defensive_rebounds(self):
         """
         Returns an ``int`` of the total number of defensive rebounds by the
         away team.
         """
-        return int(self._away_defensive_rebounds)
+        return self._away_defensive_rebounds
 
-    @property
+    @int_property_decorator
     def away_total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds by the away team.
         """
-        return int(self._away_total_rebounds)
+        return self._away_total_rebounds
 
-    @property
+    @int_property_decorator
     def away_assists(self):
         """
         Returns an ``int`` of the total number of assists by the away team.
         """
-        return int(self._away_assists)
+        return self._away_assists
 
-    @property
+    @int_property_decorator
     def away_steals(self):
         """
         Returns an ``int`` of the total number of steals by the away team.
         """
-        return int(self._away_steals)
+        return self._away_steals
 
-    @property
+    @int_property_decorator
     def away_blocks(self):
         """
         Returns an ``int`` of the total number of blocks by the away team.
         """
-        return int(self._away_blocks)
+        return self._away_blocks
 
-    @property
+    @int_property_decorator
     def away_turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers by the away team.
         """
-        return int(self._away_turnovers)
+        return self._away_turnovers
 
-    @property
+    @int_property_decorator
     def away_personal_fouls(self):
         """
         Returns an ``int`` of the total number of personal fouls by the away
         team.
         """
-        return int(self._away_personal_fouls)
+        return self._away_personal_fouls
 
-    @property
+    @int_property_decorator
     def away_points(self):
         """
         Returns an ``int`` of the number of points the away team scored.
         """
-        return int(self._away_points)
+        return self._away_points
 
-    @property
+    @float_property_decorator
     def away_true_shooting_percentage(self):
         """
         Returns a ``float`` of the away team's true shooting percentage which
         considers free throws, 2-point field goals, and 3-point field goals.
         Percentage ranges from 0-1.
         """
-        return float(self._away_true_shooting_percentage)
+        return self._away_true_shooting_percentage
 
-    @property
+    @float_property_decorator
     def away_effective_field_goal_percentage(self):
         """
         Returns a ``float`` of the away team's field goal percentage while
         giving extra weight to 3-point field goals. Percentage ranges from 0-1.
         """
-        return float(self._away_effective_field_goal_percentage)
+        return self._away_effective_field_goal_percentage
 
-    @property
+    @float_property_decorator
     def away_three_point_attempt_rate(self):
         """
         Returns a ``float`` of the percentage of field goal attempts from
         3-point range by the away team. Percentage ranges from 0-1.
         """
-        return float(self._away_three_point_attempt_rate)
+        return self._away_three_point_attempt_rate
 
-    @property
+    @float_property_decorator
     def away_free_throw_attempt_rate(self):
         """
         Returns a ``float`` of the average number of free throw attempts per
         field goal attempt by the away team.
         """
-        return float(self._away_free_throw_attempt_rate)
+        return self._away_free_throw_attempt_rate
 
-    @property
+    @float_property_decorator
     def away_offensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available offensive rebounds
         the away team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._away_offensive_rebound_percentage)
+        return self._away_offensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def away_defensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available defensive rebounds
         the away team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._away_defensive_rebound_percentage)
+        return self._away_defensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def away_total_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available rebounds the away
         team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._away_total_rebound_percentage)
+        return self._away_total_rebound_percentage
 
-    @property
+    @float_property_decorator
     def away_assist_percentage(self):
         """
         Returns a ``float`` of the percentage of the away team's field goals
         that were assisted. Percentage ranges from 0-100.
         """
-        return float(self._away_assist_percentage)
+        return self._away_assist_percentage
 
-    @property
+    @float_property_decorator
     def away_steal_percentage(self):
         """
         Returns a ``float`` of the percentage of possessions that ended in a
         steal by the away team. Percentage ranges from 0-100.
         """
-        return float(self._away_steal_percentage)
+        return self._away_steal_percentage
 
-    @property
+    @float_property_decorator
     def away_block_percentage(self):
         """
         Returns a ``float`` of the percentage of 2-point field goals that were
         blocked by the away team. Percentage ranges from 0-100.
         """
-        return float(self._away_block_percentage)
+        return self._away_block_percentage
 
-    @property
+    @float_property_decorator
     def away_turnover_percentage(self):
         """
         Returns a ``float`` of the number of times the away team turned the
         ball over per 100 possessions.
         """
-        return float(self._away_turnover_percentage)
+        return self._away_turnover_percentage
 
-    @property
+    @float_property_decorator
     def away_offensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions by the away team.
         """
-        return float(self._away_offensive_rating)
+        return self._away_offensive_rating
 
-    @property
+    @float_property_decorator
     def away_defensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions by the away team.
         """
-        return float(self._away_defensive_rating)
+        return self._away_defensive_rating
 
-    @property
+    @int_property_decorator
     def home_wins(self):
         """
         Returns an ``int`` of the number of games the home team won after the
@@ -734,11 +735,11 @@ class Boxscore(object):
         """
         try:
             wins, losses = re.findall('\d+', self._home_record)
-            return int(wins)
+            return wins
         except ValueError:
             return 0
 
-    @property
+    @int_property_decorator
     def home_losses(self):
         """
         Returns an ``int`` of the number of games the home team lost after the
@@ -746,69 +747,69 @@ class Boxscore(object):
         """
         try:
             wins, losses = re.findall('\d+', self._home_record)
-            return int(losses)
+            return losses
         except ValueError:
             return 0
 
-    @property
+    @int_property_decorator
     def home_minutes_played(self):
         """
         Returns an ``int`` of the total number of minutes the team played
         during the game.
         """
-        return int(self._home_minutes_played)
+        return self._home_minutes_played
 
-    @property
+    @int_property_decorator
     def home_field_goals(self):
         """
         Returns an ``int`` of the total number of field goals made by the home
         team.
         """
-        return int(self._home_field_goals)
+        return self._home_field_goals
 
-    @property
+    @int_property_decorator
     def home_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goal attempts by the
         home team.
         """
-        return int(self._home_field_goal_attempts)
+        return self._home_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def home_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of field goals made divided by the
         total number of field goal attempts by the home team. Percentage ranges
         from 0-1.
         """
-        return float(self._home_field_goal_percentage)
+        return self._home_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def home_three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals made
         by the home team.
         """
-        return int(self._home_three_point_field_goals)
+        return self._home_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def home_three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goal
         attempts by the home team.
         """
-        return int(self._home_three_point_field_goal_attempts)
+        return self._home_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def home_three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of three point field goals made
         divided by the number of three point field goal attempts by the home
         team. Percentage ranges from 0-1.
         """
-        return float(self._home_three_point_field_goal_percentage)
+        return self._home_three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def home_two_point_field_goals(self):
         """
         Returns an ``int`` of the total number of two point field goals made
@@ -816,7 +817,7 @@ class Boxscore(object):
         """
         return self.home_field_goals - self.home_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def home_two_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of two point field goal attempts
@@ -825,7 +826,7 @@ class Boxscore(object):
         return self.home_field_goal_attempts - \
             self.home_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def home_two_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of two point field goals made divided
@@ -836,200 +837,200 @@ class Boxscore(object):
             float(self.home_two_point_field_goal_attempts)
         return round(float(result), 3)
 
-    @property
+    @int_property_decorator
     def home_free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made by the home
         team.
         """
-        return int(self._home_free_throws)
+        return self._home_free_throws
 
-    @property
+    @int_property_decorator
     def home_free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts by the
         home team.
         """
-        return int(self._home_free_throw_attempts)
+        return self._home_free_throw_attempts
 
-    @property
+    @float_property_decorator
     def home_free_throw_percentage(self):
         """
         Returns a ``float`` of the number of free throws made divided by the
         number of free throw attempts  by the home team.
         """
-        return float(self._home_free_throw_percentage)
+        return self._home_free_throw_percentage
 
-    @property
+    @int_property_decorator
     def home_offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds by the
         home team.
         """
-        return int(self._home_offensive_rebounds)
+        return self._home_offensive_rebounds
 
-    @property
+    @int_property_decorator
     def home_defensive_rebounds(self):
         """
         Returns an ``int`` of the total number of defensive rebounds by the
         home team.
         """
-        return int(self._home_defensive_rebounds)
+        return self._home_defensive_rebounds
 
-    @property
+    @int_property_decorator
     def home_total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds by the home team.
         """
-        return int(self._home_total_rebounds)
+        return self._home_total_rebounds
 
-    @property
+    @int_property_decorator
     def home_assists(self):
         """
         Returns an ``int`` of the total number of assists by the home team.
         """
-        return int(self._home_assists)
+        return self._home_assists
 
-    @property
+    @int_property_decorator
     def home_steals(self):
         """
         Returns an ``int`` of the total number of steals by the home team.
         """
-        return int(self._home_steals)
+        return self._home_steals
 
-    @property
+    @int_property_decorator
     def home_blocks(self):
         """
         Returns an ``int`` of the total number of blocks by the home team.
         """
-        return int(self._home_blocks)
+        return self._home_blocks
 
-    @property
+    @int_property_decorator
     def home_turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers by the home team.
         """
-        return int(self._home_turnovers)
+        return self._home_turnovers
 
-    @property
+    @int_property_decorator
     def home_personal_fouls(self):
         """
         Returns an ``int`` of the total number of personal fouls by the home
         team.
         """
-        return int(self._home_personal_fouls)
+        return self._home_personal_fouls
 
-    @property
+    @int_property_decorator
     def home_points(self):
         """
         Returns an ``int`` of the number of points the home team scored.
         """
-        return int(self._home_points)
+        return self._home_points
 
-    @property
+    @float_property_decorator
     def home_true_shooting_percentage(self):
         """
         Returns a ``float`` of the home team's true shooting percentage which
         considers free throws, 2-point field goals, and 3-point field goals.
         Percentage ranges from 0-1.
         """
-        return float(self._home_true_shooting_percentage)
+        return self._home_true_shooting_percentage
 
-    @property
+    @float_property_decorator
     def home_effective_field_goal_percentage(self):
         """
         Returns a ``float`` of the home team's field goal percentage while
         giving extra weight to 3-point field goals. Percentage ranges from 0-1.
         """
-        return float(self._home_effective_field_goal_percentage)
+        return self._home_effective_field_goal_percentage
 
-    @property
+    @float_property_decorator
     def home_three_point_attempt_rate(self):
         """
         Returns a ``float`` of the percentage of field goal attempts from
         3-point range by the home team. Percentage ranges from 0-1.
         """
-        return float(self._home_three_point_attempt_rate)
+        return self._home_three_point_attempt_rate
 
-    @property
+    @float_property_decorator
     def home_free_throw_attempt_rate(self):
         """
         Returns a ``float`` of the average number of free throw attempts per
         field goal attempt by the home team.
         """
-        return float(self._home_free_throw_attempt_rate)
+        return self._home_free_throw_attempt_rate
 
-    @property
+    @float_property_decorator
     def home_offensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available offensive rebounds
         the home team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._home_offensive_rebound_percentage)
+        return self._home_offensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def home_defensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available defensive rebounds
         the home team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._home_defensive_rebound_percentage)
+        return self._home_defensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def home_total_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available rebounds the home
         team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._home_total_rebound_percentage)
+        return self._home_total_rebound_percentage
 
-    @property
+    @float_property_decorator
     def home_assist_percentage(self):
         """
         Returns a ``float`` of the percentage of the home team's field goals
         that were assisted. Percentage ranges from 0-100.
         """
-        return float(self._home_assist_percentage)
+        return self._home_assist_percentage
 
-    @property
+    @float_property_decorator
     def home_steal_percentage(self):
         """
         Returns a ``float`` of the percentage of possessions that ended in a
         steal by the home team. Percentage ranges from 0-100.
         """
-        return float(self._home_steal_percentage)
+        return self._home_steal_percentage
 
-    @property
+    @float_property_decorator
     def home_block_percentage(self):
         """
         Returns a ``float`` of the percentage of 2-point field goals that were
         blocked by the home team. Percentage ranges from 0-100.
         """
-        return float(self._home_block_percentage)
+        return self._home_block_percentage
 
-    @property
+    @float_property_decorator
     def home_turnover_percentage(self):
         """
         Returns a ``float`` of the number of times the home team turned the
         ball over per 100 possessions.
         """
-        return float(self._home_turnover_percentage)
+        return self._home_turnover_percentage
 
-    @property
+    @float_property_decorator
     def home_offensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions by the home team.
         """
-        return float(self._home_offensive_rating)
+        return self._home_offensive_rating
 
-    @property
+    @float_property_decorator
     def home_defensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions by the away team.
         """
-        return float(self._home_defensive_rating)
+        return self._home_defensive_rating
 
 
 class Boxscores:

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -29,6 +29,21 @@ def int_property_decorator(func):
         try:
             return int(value)
         except ValueError:
+            # If there is no value, default to None
+            return None
+    return wrapper
+
+
+def int_property_decorator_default_zero(func):
+    @property
+    @wraps(func)
+    def wrapper(*args):
+        index = args[0]._index
+        prop = func(*args)
+        value = cleanup(prop[index])
+        try:
+            return int(value)
+        except ValueError:
             # If there is no value, default to 0
             return 0
     return wrapper
@@ -44,8 +59,8 @@ def float_property_decorator(func):
         try:
             return float(value)
         except ValueError:
-            # If there is no value, default to 0.0
-            return 0.0
+            # If there is no value, default to None
+            return None
     return wrapper
 
 
@@ -1297,7 +1312,7 @@ class Player(object):
         """
         return self._half_court_heaves_made
 
-    @int_property_decorator
+    @int_property_decorator_default_zero
     def point_guard_percentage(self):
         """
         Returns an ``int`` of the percentage of time the player spent as a
@@ -1306,7 +1321,7 @@ class Player(object):
         """
         return self._point_guard_percentage
 
-    @int_property_decorator
+    @int_property_decorator_default_zero
     def shooting_guard_percentage(self):
         """
         Returns an ``int`` of the percentage of time the player spent as a
@@ -1315,7 +1330,7 @@ class Player(object):
         """
         return self._shooting_guard_percentage
 
-    @int_property_decorator
+    @int_property_decorator_default_zero
     def small_forward_percentage(self):
         """
         Returns an ``int`` of the percentage of time the player spent as a
@@ -1324,7 +1339,7 @@ class Player(object):
         """
         return self._small_forward_percentage
 
-    @int_property_decorator
+    @int_property_decorator_default_zero
     def power_forward_percentage(self):
         """
         Returns an ``int`` of the percentage of time the player spent as a
@@ -1333,7 +1348,7 @@ class Player(object):
         """
         return self._power_forward_percentage
 
-    @int_property_decorator
+    @int_property_decorator_default_zero
     def center_percentage(self):
         """
         Returns an ``int`` of the percentage of time the player spent as a

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import re
 from datetime import datetime
+from functools import wraps
 from pyquery import PyQuery as pq
 from .. import utils
 from .constants import NATIONALITY, PLAYER_SCHEME, PLAYER_URL, ROSTER_URL
@@ -20,6 +21,7 @@ def cleanup(prop):
 
 def int_property_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
@@ -34,6 +36,7 @@ def int_property_decorator(func):
 
 def float_property_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
@@ -48,6 +51,7 @@ def float_property_decorator(func):
 
 def most_recent_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         season = args[0]._most_recent_season
         seasons = args[0]._season

--- a/sportsreference/nba/schedule.py
+++ b/sportsreference/nba/schedule.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+from ..decorators import float_property_decorator, int_property_decorator
 from .constants import (SCHEDULE_SCHEME,
                         SCHEDULE_URL)
 from datetime import datetime
@@ -184,13 +185,13 @@ class Game(object):
         """
         return self.boxscore.dataframe
 
-    @property
+    @int_property_decorator
     def game(self):
         """
         Returns an ``int`` to indicate which game in the season was requested.
         The first game of the season returns 1.
         """
-        return int(self._game)
+        return self._game
 
     @property
     def date(self):
@@ -244,268 +245,268 @@ class Game(object):
             return LOSS
         return WIN
 
-    @property
+    @int_property_decorator
     def points_scored(self):
         """
         Returns an ``int`` of the number of points the team scored during the
         game.
         """
-        return int(self._points_scored)
+        return self._points_scored
 
-    @property
+    @int_property_decorator
     def points_allowed(self):
         """
         Returns an ``int`` of the number of points the team allowed during the
         game.
         """
-        return int(self._points_allowed)
+        return self._points_allowed
 
-    @property
+    @int_property_decorator
     def field_goals(self):
         """
         Returns an ``int`` of the total number of field goals made by the team.
         """
-        return int(self._field_goals)
+        return self._field_goals
 
-    @property
+    @int_property_decorator
     def field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goal attempts by the
         team.
         """
-        return int(self._field_goal_attempts)
+        return self._field_goal_attempts
 
-    @property
+    @float_property_decorator
     def field_goal_percentage(self):
         """
         Returns a ``float`` of the number of field goals made divided by the
         total number of field goal attempts by the team. Percentage ranges from
         0-1.
         """
-        return float(self._field_goal_percentage)
+        return self._field_goal_percentage
 
-    @property
+    @int_property_decorator
     def three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals made
         by the team.
         """
-        return int(self._three_point_field_goals)
+        return self._three_point_field_goals
 
-    @property
+    @int_property_decorator
     def three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goal
         attempts by the team.
         """
-        return int(self._three_point_field_goal_attempts)
+        return self._three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of three point field goals made
         divided by the number of three point field goal attempts by the team.
         Percentage ranges from 0-1.
         """
-        return float(self._three_point_field_goal_percentage)
+        return self._three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made by the team.
         """
-        return int(self._free_throws)
+        return self._free_throws
 
-    @property
+    @int_property_decorator
     def free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts by the
         team.
         """
-        return int(self._free_throw_attempts)
+        return self._free_throw_attempts
 
-    @property
+    @float_property_decorator
     def free_throw_percentage(self):
         """
         Returns a ``float`` of the number of free throws made divided by the
         number of free throw attempts by the team.
         """
-        return float(self._free_throw_percentage)
+        return self._free_throw_percentage
 
-    @property
+    @int_property_decorator
     def offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds by the
         team.
         """
-        return int(self._offensive_rebounds)
+        return self._offensive_rebounds
 
-    @property
+    @int_property_decorator
     def total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds by the team.
         """
-        return int(self._total_rebounds)
+        return self._total_rebounds
 
-    @property
+    @int_property_decorator
     def assists(self):
         """
         Returns an ``int`` of the total number of assists by the team.
         """
-        return int(self._assists)
+        return self._assists
 
-    @property
+    @int_property_decorator
     def steals(self):
         """
         Returns an ``int`` of the total number of steals by the team.
         """
-        return int(self._steals)
+        return self._steals
 
-    @property
+    @int_property_decorator
     def blocks(self):
         """
         Returns an ``int`` of the total number of blocks by the team.
         """
-        return int(self._blocks)
+        return self._blocks
 
-    @property
+    @int_property_decorator
     def turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers by the team.
         """
-        return int(self._turnovers)
+        return self._turnovers
 
-    @property
+    @int_property_decorator
     def personal_fouls(self):
         """
         Returns an ``int`` of the total number of personal fouls by the team.
         """
-        return int(self._personal_fouls)
+        return self._personal_fouls
 
-    @property
+    @int_property_decorator
     def opp_field_goals(self):
         """
         Returns an ``int`` of the total number of field goals made by the
         opponent.
         """
-        return int(self._opp_field_goals)
+        return self._opp_field_goals
 
-    @property
+    @int_property_decorator
     def opp_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goal attempts by the
         opponent.
         """
-        return int(self._opp_field_goal_attempts)
+        return self._opp_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def opp_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of field goals made divided by the
         total number of field goal attempts by the opponent. Percentage ranges
         from 0-1.
         """
-        return float(self._opp_field_goal_percentage)
+        return self._opp_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def opp_three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals made
         by the opponent.
         """
-        return int(self._opp_three_point_field_goals)
+        return self._opp_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def opp_three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goal
         attempts by the opponent.
         """
-        return int(self._opp_three_point_field_goal_attempts)
+        return self._opp_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def opp_three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of three point field goals made
         divided by the number of three point field goal attempts by the
         opponent. Percentage ranges from 0-1.
         """
-        return float(self._opp_three_point_field_goal_percentage)
+        return self._opp_three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def opp_free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made by the
         opponent.
         """
-        return int(self._opp_free_throws)
+        return self._opp_free_throws
 
-    @property
+    @int_property_decorator
     def opp_free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts by the
         opponent.
         """
-        return int(self._opp_free_throw_attempts)
+        return self._opp_free_throw_attempts
 
-    @property
+    @float_property_decorator
     def opp_free_throw_percentage(self):
         """
         Returns a ``float`` of the number of free throws made divided by the
         number of free throw attempts by the opponent.
         """
-        return float(self._opp_free_throw_percentage)
+        return self._opp_free_throw_percentage
 
-    @property
+    @int_property_decorator
     def opp_offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds by the
         opponent.
         """
-        return int(self._opp_offensive_rebounds)
+        return self._opp_offensive_rebounds
 
-    @property
+    @int_property_decorator
     def opp_total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds by the opponent.
         """
-        return int(self._opp_total_rebounds)
+        return self._opp_total_rebounds
 
-    @property
+    @int_property_decorator
     def opp_assists(self):
         """
         Returns an ``int`` of the total number of assists by the opponent.
         """
-        return int(self._opp_assists)
+        return self._opp_assists
 
-    @property
+    @int_property_decorator
     def opp_steals(self):
         """
         Returns an ``int`` of the total number of steals by the opponent.
         """
-        return int(self._opp_steals)
+        return self._opp_steals
 
-    @property
+    @int_property_decorator
     def opp_blocks(self):
         """
         Returns an ``int`` of the total number of blocks by the opponent.
         """
-        return int(self._opp_blocks)
+        return self._opp_blocks
 
-    @property
+    @int_property_decorator
     def opp_turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers by the opponent.
         """
-        return int(self._opp_turnovers)
+        return self._opp_turnovers
 
-    @property
+    @int_property_decorator
     def opp_personal_fouls(self):
         """
         Returns an ``int`` of the total number of personal fouls by the
         opponent.
         """
-        return int(self._opp_personal_fouls)
+        return self._opp_personal_fouls
 
 
 class Schedule:

--- a/sportsreference/nba/schedule.py
+++ b/sportsreference/nba/schedule.py
@@ -509,7 +509,7 @@ class Game(object):
         return self._opp_personal_fouls
 
 
-class Schedule:
+class Schedule(object):
     """
     An object of the given team's schedule.
 
@@ -648,7 +648,11 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe)
+            df = game.dataframe
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)
 
     @property
@@ -662,5 +666,9 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe_extended)
+            df = game.dataframe_extended
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)

--- a/sportsreference/nba/teams.py
+++ b/sportsreference/nba/teams.py
@@ -2,6 +2,7 @@ import pandas as pd
 import re
 from .constants import PARSING_SCHEME, SEASON_PAGE_URL
 from pyquery import PyQuery as pq
+from ..decorators import float_property_decorator, int_property_decorator
 from .. import utils
 from .roster import Roster
 from .schedule import Schedule
@@ -175,13 +176,13 @@ class Team(object):
         }
         return pd.DataFrame([fields_to_include], index=[self._abbreviation])
 
-    @property
+    @int_property_decorator
     def rank(self):
         """
         Returns an ``int`` of the team's rank based on the number of points
         they score per game.
         """
-        return int(self._rank)
+        return self._rank
 
     @property
     def abbreviation(self):
@@ -215,359 +216,359 @@ class Team(object):
         """
         return self._name
 
-    @property
+    @int_property_decorator
     def games_played(self):
         """
         Returns an ``int`` of the total number of games the team has played
         during the season.
         """
-        return int(self._games_played)
+        return self._games_played
 
-    @property
+    @int_property_decorator
     def minutes_played(self):
         """
         Returns an ``int`` of the total number of minutes played by all players
         on the team during the season.
         """
-        return int(self._minutes_played)
+        return self._minutes_played
 
-    @property
+    @int_property_decorator
     def field_goals(self):
         """
         Returns an ``int`` of the total number of field goals the team has made
         during the season.
         """
-        return int(self._field_goals)
+        return self._field_goals
 
-    @property
+    @int_property_decorator
     def field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goals the team has
         attempted during the season.
         """
-        return int(self._field_goal_attempts)
+        return self._field_goal_attempts
 
-    @property
+    @float_property_decorator
     def field_goal_percentage(self):
         """
         Returns a ``float`` of the percentage of field goals made divided by
         the number of attempts. Percentage ranges from 0-1.
         """
-        return float(self._field_goal_percentage)
+        return self._field_goal_percentage
 
-    @property
+    @int_property_decorator
     def three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals the
         team has made during the season.
         """
-        return int(self._three_point_field_goals)
+        return self._three_point_field_goals
 
-    @property
+    @int_property_decorator
     def three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goals the
         team has attempted during the season.
         """
-        return int(self._three_point_field_goal_attempts)
+        return self._three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the percentage of three point field goals made
         divided by the number of attempts. Percentage ranges from 0-1.
         """
-        return float(self._three_point_field_goal_percentage)
+        return self._three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def two_point_field_goals(self):
         """
         Returns an ``int`` of the total number of two point field goals the
         team has made during the season.
         """
-        return int(self._two_point_field_goals)
+        return self._two_point_field_goals
 
-    @property
+    @int_property_decorator
     def two_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of two point field goals the
         team has attempted during the season.
         """
-        return int(self._two_point_field_goal_attempts)
+        return self._two_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def two_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the percentage of two point field goals made
         divided by the number of attempts. Percentage ranges from 0-1.
         """
-        return float(self._two_point_field_goal_percentage)
+        return self._two_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made during the
         season.
         """
-        return int(self._free_throws)
+        return self._free_throws
 
-    @property
+    @int_property_decorator
     def free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts during
         the season.
         """
-        return int(self._free_throw_attempts)
+        return self._free_throw_attempts
 
-    @property
+    @float_property_decorator
     def free_throw_percentage(self):
         """
         Returns a ``float`` of the percentage of free throws made divided by
         the attempts. Percentage ranges from 0-1.
         """
-        return float(self._free_throw_percentage)
+        return self._free_throw_percentage
 
-    @property
+    @int_property_decorator
     def offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds the team
         has grabbed.
         """
-        return int(self._offensive_rebounds)
+        return self._offensive_rebounds
 
-    @property
+    @int_property_decorator
     def defensive_rebounds(self):
         """
         Returns an ``int`` of the total number of defensive rebounds the team
         has grabbed.
         """
-        return int(self._defensive_rebounds)
+        return self._defensive_rebounds
 
-    @property
+    @int_property_decorator
     def total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds the team has
         grabbed.
         """
-        return int(self._total_rebounds)
+        return self._total_rebounds
 
-    @property
+    @int_property_decorator
     def assists(self):
         """
         Returns an ``int`` of the total number of field goals that were
         assisted.
         """
-        return int(self._assists)
+        return self._assists
 
-    @property
+    @int_property_decorator
     def steals(self):
         """
         Returns an ``int`` of the total number of times the team stole the ball
         from the opponent.
         """
-        return int(self._steals)
+        return self._steals
 
-    @property
+    @int_property_decorator
     def blocks(self):
         """
         Returns an ``int`` of the total number of times the team blocked an
         opponent's shot.
         """
-        return int(self._blocks)
+        return self._blocks
 
-    @property
+    @int_property_decorator
     def turnovers(self):
         """
         Returns an ``int`` of the total number of times the team has turned the
         ball over.
         """
-        return int(self._turnovers)
+        return self._turnovers
 
-    @property
+    @int_property_decorator
     def personal_fouls(self):
         """
         Returns an ``int`` of the total number of times the team has fouled an
         opponent.
         """
-        return int(self._personal_fouls)
+        return self._personal_fouls
 
-    @property
+    @int_property_decorator
     def points(self):
         """
         Returns an ``int`` of the total number of points the team has scored
         during the season.
         """
-        return int(self._points)
+        return self._points
 
-    @property
+    @int_property_decorator
     def opp_field_goals(self):
         """
         Returns an ``int`` of the total number of field goals the opponents
         made during the season.
         """
-        return int(self._opp_field_goals)
+        return self._opp_field_goals
 
-    @property
+    @int_property_decorator
     def opp_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goals the opponents
         attempted during the season.
         """
-        return int(self._opp_field_goal_attempts)
+        return self._opp_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def opp_field_goal_percentage(self):
         """
         Returns a ``float`` of the percentage of field goals made divided by
         the number of attempts by the opponent. Percentage ranges from 0-1.
         """
-        return float(self._opp_field_goal_percentage)
+        return self._opp_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def opp_three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals the
         opponent made during the season.
         """
-        return int(self._opp_three_point_field_goals)
+        return self._opp_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def opp_three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goals the
         opponent attempted during the season.
         """
-        return int(self._opp_three_point_field_goal_attempts)
+        return self._opp_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def opp_three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the percentage of three point field goals made
         divided by the number of attempts by the opponent. Percentage ranges
         from 0-1.
         """
-        return float(self._opp_three_point_field_goal_percentage)
+        return self._opp_three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def opp_two_point_field_goals(self):
         """
         Returns an ``int`` of the total number of two point field goals the
         opponent made during the season.
         """
-        return int(self._opp_two_point_field_goals)
+        return self._opp_two_point_field_goals
 
-    @property
+    @int_property_decorator
     def opp_two_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of two point field goals the
         opponent attempted during the season.
         """
-        return int(self._opp_two_point_field_goal_attempts)
+        return self._opp_two_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def opp_two_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the percentage of two point field goals made
         divided by the number of attempts by the opponent. Percentage ranges
         from 0-1.
         """
-        return float(self._opp_two_point_field_goal_percentage)
+        return self._opp_two_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def opp_free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made during the
         season by the opponent.
         """
-        return int(self._opp_free_throws)
+        return self._opp_free_throws
 
-    @property
+    @int_property_decorator
     def opp_free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts during
         the season by the opponent.
         """
-        return int(self._opp_free_throw_attempts)
+        return self._opp_free_throw_attempts
 
-    @property
+    @float_property_decorator
     def opp_free_throw_percentage(self):
         """
         Returns a ``float`` of the percentage of free throws made divided by
         the attempts by the opponent. Percentage ranges from 0-1.
         """
-        return float(self._opp_free_throw_percentage)
+        return self._opp_free_throw_percentage
 
-    @property
+    @int_property_decorator
     def opp_offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds the
         opponent grabbed.
         """
-        return int(self._opp_offensive_rebounds)
+        return self._opp_offensive_rebounds
 
-    @property
+    @int_property_decorator
     def opp_defensive_rebounds(self):
         """
         Returns an ``int`` of the total number of defensive rebounds the
         opponent grabbed.
         """
-        return int(self._opp_defensive_rebounds)
+        return self._opp_defensive_rebounds
 
-    @property
+    @int_property_decorator
     def opp_total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds the opponent
         grabbed.
         """
-        return int(self._opp_total_rebounds)
+        return self._opp_total_rebounds
 
-    @property
+    @int_property_decorator
     def opp_assists(self):
         """
         Returns an ``int`` of the total number of field goals that were
         assisted by the opponent.
         """
-        return int(self._opp_assists)
+        return self._opp_assists
 
-    @property
+    @int_property_decorator
     def opp_steals(self):
         """
         Returns an ``int`` of the total number of times the opponent stole the
         ball from the team.
         """
-        return int(self._opp_steals)
+        return self._opp_steals
 
-    @property
+    @int_property_decorator
     def opp_blocks(self):
         """
         Returns an ``int`` of the total number of times the opponent blocked
         the team's shot.
         """
-        return int(self._opp_blocks)
+        return self._opp_blocks
 
-    @property
+    @int_property_decorator
     def opp_turnovers(self):
         """
         Returns an ``int`` of the total number of times the opponent turned the
         ball over.
         """
-        return int(self._opp_turnovers)
+        return self._opp_turnovers
 
-    @property
+    @int_property_decorator
     def opp_personal_fouls(self):
         """
         Returns an ``int`` of the total number of times the opponent fouled the
         team.
         """
-        return int(self._opp_personal_fouls)
+        return self._opp_personal_fouls
 
-    @property
+    @int_property_decorator
     def opp_points(self):
         """
         Returns an ``int`` of the total number of points the team has been
         scored on during the season.
         """
-        return int(self._opp_points)
+        return self._opp_points
 
 
 class Teams:

--- a/sportsreference/ncaab/boxscore.py
+++ b/sportsreference/ncaab/boxscore.py
@@ -2,6 +2,7 @@ import pandas as pd
 import re
 from pyquery import PyQuery as pq
 from .. import utils
+from ..decorators import float_property_decorator, int_property_decorator
 from .constants import (BOXSCORE_ELEMENT_INDEX,
                         BOXSCORE_SCHEME,
                         BOXSCORE_URL,
@@ -485,15 +486,15 @@ class Boxscore(object):
             return str(self._home_name)
         return utils._parse_abbreviation(self._home_name)
 
-    @property
+    @float_property_decorator
     def pace(self):
         """
         Returns a ``float`` of the game's overall pace, measured by the number
         of possessions per 40 minutes.
         """
-        return float(self._pace)
+        return self._pace
 
-    @property
+    @int_property_decorator
     def away_ranking(self):
         """
         Returns an ``int`` of the away team's ranking during the week, or
@@ -501,7 +502,7 @@ class Boxscore(object):
         """
         return self._away_ranking
 
-    @property
+    @float_property_decorator
     def away_win_percentage(self):
         """
         Returns a ``float`` of the percentage of games the away team has won
@@ -514,7 +515,7 @@ class Boxscore(object):
         except ZeroDivisionError:
             return 0.0
 
-    @property
+    @int_property_decorator
     def away_wins(self):
         """
         Returns an ``int`` of the number of games the team has won after the
@@ -522,11 +523,11 @@ class Boxscore(object):
         """
         try:
             wins, losses = re.findall('\d+', self._away_record)
-            return int(wins)
+            return wins
         except ValueError:
             return 0
 
-    @property
+    @int_property_decorator
     def away_losses(self):
         """
         Returns an ``int`` of the number of games the team has lost after the
@@ -534,292 +535,289 @@ class Boxscore(object):
         """
         try:
             wins, losses = re.findall('\d+', self._away_record)
-            return int(losses)
+            return losses
         except ValueError:
             return 0
 
-    @property
+    @int_property_decorator
     def away_minutes_played(self):
         """
         Returns an ``int`` of the total number of minutes the team played
         during the game.
         """
-        return int(self._away_minutes_played)
+        return self._away_minutes_played
 
-    @property
+    @int_property_decorator
     def away_field_goals(self):
         """
         Returns an ``int`` of the total number of field goals made by the away
         team.
         """
-        return int(self._away_field_goals)
+        return self._away_field_goals
 
-    @property
+    @int_property_decorator
     def away_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goal attempts by the
         away team.
         """
-        return int(self._away_field_goal_attempts)
+        return self._away_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def away_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of field goals made divided by the
         total number of field goal attempts by the away team. Percentage ranges
         from 0-1.
         """
-        return float(self._away_field_goal_percentage)
+        return self._away_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def away_three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals made
         by the away team.
         """
-        return int(self._away_three_point_field_goals)
+        return self._away_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def away_three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goal
         attempts by the away team.
         """
-        return int(self._away_three_point_field_goal_attempts)
+        return self._away_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def away_three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of three point field goals made
         divided by the number of three point field goal attempts by the away
         team. Percentage ranges from 0-1.
         """
-        return float(self._away_three_point_field_goal_percentage)
+        return self._away_three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def away_two_point_field_goals(self):
         """
         Returns an ``int`` of the total number of two point field goals made
         by the away team.
         """
-        return int(self._away_two_point_field_goals)
+        return self._away_two_point_field_goals
 
-    @property
+    @int_property_decorator
     def away_two_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of two point field goal attempts
         by the away team.
         """
-        return int(self._away_two_point_field_goal_attempts)
+        return self._away_two_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def away_two_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of two point field goals made divided
         by the number of two point field goal attempts by the away team.
         Percentage ranges from 0-1.
         """
-        return float(self._away_two_point_field_goal_percentage)
+        return self._away_two_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def away_free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made by the away
         team.
         """
-        return int(self._away_free_throws)
+        return self._away_free_throws
 
-    @property
+    @int_property_decorator
     def away_free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts by the
         away team.
         """
-        return int(self._away_free_throw_attempts)
+        return self._away_free_throw_attempts
 
-    @property
+    @float_property_decorator
     def away_free_throw_percentage(self):
         """
         Returns a ``float`` of the number of free throws made divided by the
         number of free throw attempts  by the away team.
         """
-        try:
-            return float(self._away_free_throw_percentage)
-        except ValueError:
-            return 0.0
+        return self._away_free_throw_percentage
 
-    @property
+    @int_property_decorator
     def away_offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds by the
         away team.
         """
-        return int(self._away_offensive_rebounds)
+        return self._away_offensive_rebounds
 
-    @property
+    @int_property_decorator
     def away_defensive_rebounds(self):
         """
         Returns an ``int`` of the total number of defensive rebounds by the
         away team.
         """
-        return int(self._away_defensive_rebounds)
+        return self._away_defensive_rebounds
 
-    @property
+    @int_property_decorator
     def away_total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds by the away team.
         """
-        return int(self._away_total_rebounds)
+        return self._away_total_rebounds
 
-    @property
+    @int_property_decorator
     def away_assists(self):
         """
         Returns an ``int`` of the total number of assists by the away team.
         """
-        return int(self._away_assists)
+        return self._away_assists
 
-    @property
+    @int_property_decorator
     def away_steals(self):
         """
         Returns an ``int`` of the total number of steals by the away team.
         """
-        return int(self._away_steals)
+        return self._away_steals
 
-    @property
+    @int_property_decorator
     def away_blocks(self):
         """
         Returns an ``int`` of the total number of blocks by the away team.
         """
-        return int(self._away_blocks)
+        return self._away_blocks
 
-    @property
+    @int_property_decorator
     def away_turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers by the away team.
         """
-        return int(self._away_turnovers)
+        return self._away_turnovers
 
-    @property
+    @int_property_decorator
     def away_personal_fouls(self):
         """
         Returns an ``int`` of the total number of personal fouls by the away
         team.
         """
-        return int(self._away_personal_fouls)
+        return self._away_personal_fouls
 
-    @property
+    @int_property_decorator
     def away_points(self):
         """
         Returns an ``int`` of the number of points the away team scored.
         """
-        return int(self._away_points)
+        return self._away_points
 
-    @property
+    @float_property_decorator
     def away_true_shooting_percentage(self):
         """
         Returns a ``float`` of the away team's true shooting percentage which
         considers free throws, 2-point field goals, and 3-point field goals.
         Percentage ranges from 0-1.
         """
-        return float(self._away_true_shooting_percentage)
+        return self._away_true_shooting_percentage
 
-    @property
+    @float_property_decorator
     def away_effective_field_goal_percentage(self):
         """
         Returns a ``float`` of the away team's field goal percentage while
         giving extra weight to 3-point field goals. Percentage ranges from 0-1.
         """
-        return float(self._away_effective_field_goal_percentage)
+        return self._away_effective_field_goal_percentage
 
-    @property
+    @float_property_decorator
     def away_three_point_attempt_rate(self):
         """
         Returns a ``float`` of the percentage of field goal attempts from
         3-point range by the away team. Percentage ranges from 0-1.
         """
-        return float(self._away_three_point_attempt_rate)
+        return self._away_three_point_attempt_rate
 
-    @property
+    @float_property_decorator
     def away_free_throw_attempt_rate(self):
         """
         Returns a ``float`` of the average number of free throw attempts per
         field goal attempt by the away team.
         """
-        return float(self._away_free_throw_attempt_rate)
+        return self._away_free_throw_attempt_rate
 
-    @property
+    @float_property_decorator
     def away_offensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available offensive rebounds
         the away team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._away_offensive_rebound_percentage)
+        return self._away_offensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def away_defensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available defensive rebounds
         the away team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._away_defensive_rebound_percentage)
+        return self._away_defensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def away_total_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available rebounds the away
         team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._away_total_rebound_percentage)
+        return self._away_total_rebound_percentage
 
-    @property
+    @float_property_decorator
     def away_assist_percentage(self):
         """
         Returns a ``float`` of the percentage of the away team's field goals
         that were assisted. Percentage ranges from 0-100.
         """
-        return float(self._away_assist_percentage)
+        return self._away_assist_percentage
 
-    @property
+    @float_property_decorator
     def away_steal_percentage(self):
         """
         Returns a ``float`` of the percentage of possessions that ended in a
         steal by the away team. Percentage ranges from 0-100.
         """
-        return float(self._away_steal_percentage)
+        return self._away_steal_percentage
 
-    @property
+    @float_property_decorator
     def away_block_percentage(self):
         """
         Returns a ``float`` of the percentage of 2-point field goals that were
         blocked by the away team. Percentage ranges from 0-100.
         """
-        return float(self._away_block_percentage)
+        return self._away_block_percentage
 
-    @property
+    @float_property_decorator
     def away_turnover_percentage(self):
         """
         Returns a ``float`` of the number of times the away team turned the
         ball over per 100 possessions.
         """
-        return float(self._away_turnover_percentage)
+        return self._away_turnover_percentage
 
-    @property
+    @float_property_decorator
     def away_offensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions by the away team.
         """
-        return float(self._away_offensive_rating)
+        return self._away_offensive_rating
 
-    @property
+    @float_property_decorator
     def away_defensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions by the away team.
         """
-        return float(self._away_defensive_rating)
+        return self._away_defensive_rating
 
-    @property
+    @int_property_decorator
     def home_ranking(self):
         """
         Returns an ``int`` of the home team's ranking during the week, or
@@ -827,7 +825,7 @@ class Boxscore(object):
         """
         return self._home_ranking
 
-    @property
+    @float_property_decorator
     def home_win_percentage(self):
         """
         Returns a ``float`` of the percentage of games the home team has won
@@ -840,7 +838,7 @@ class Boxscore(object):
         except ZeroDivisionError:
             return 0.0
 
-    @property
+    @int_property_decorator
     def home_wins(self):
         """
         Returns an ``int`` of the number of games the home team won after the
@@ -848,11 +846,11 @@ class Boxscore(object):
         """
         try:
             wins, losses = re.findall('\d+', self._home_record)
-            return int(wins)
+            return wins
         except ValueError:
             return 0
 
-    @property
+    @int_property_decorator
     def home_losses(self):
         """
         Returns an ``int`` of the number of games the home team lost after the
@@ -860,290 +858,287 @@ class Boxscore(object):
         """
         try:
             wins, losses = re.findall('\d+', self._home_record)
-            return int(losses)
+            return losses
         except ValueError:
             return 0
 
-    @property
+    @int_property_decorator
     def home_minutes_played(self):
         """
         Returns an ``int`` of the total number of minutes the team played
         during the game.
         """
-        return int(self._home_minutes_played)
+        return self._home_minutes_played
 
-    @property
+    @int_property_decorator
     def home_field_goals(self):
         """
         Returns an ``int`` of the total number of field goals made by the home
         team.
         """
-        return int(self._home_field_goals)
+        return self._home_field_goals
 
-    @property
+    @int_property_decorator
     def home_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goal attempts by the
         home team.
         """
-        return int(self._home_field_goal_attempts)
+        return self._home_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def home_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of field goals made divided by the
         total number of field goal attempts by the home team. Percentage ranges
         from 0-1.
         """
-        return float(self._home_field_goal_percentage)
+        return self._home_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def home_three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals made
         by the home team.
         """
-        return int(self._home_three_point_field_goals)
+        return self._home_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def home_three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goal
         attempts by the home team.
         """
-        return int(self._home_three_point_field_goal_attempts)
+        return self._home_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def home_three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of three point field goals made
         divided by the number of three point field goal attempts by the home
         team. Percentage ranges from 0-1.
         """
-        return float(self._home_three_point_field_goal_percentage)
+        return self._home_three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def home_two_point_field_goals(self):
         """
         Returns an ``int`` of the total number of two point field goals made
         by the home team.
         """
-        return int(self._home_two_point_field_goals)
+        return self._home_two_point_field_goals
 
-    @property
+    @int_property_decorator
     def home_two_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of two point field goal attempts
         by the home team.
         """
-        return int(self._home_two_point_field_goal_attempts)
+        return self._home_two_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def home_two_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of two point field goals made divided
         by the number of two point field goal attempts by the home team.
         Percentage ranges from 0-1.
         """
-        return float(self._home_two_point_field_goal_percentage)
+        return self._home_two_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def home_free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made by the home
         team.
         """
-        return int(self._home_free_throws)
+        return self._home_free_throws
 
-    @property
+    @int_property_decorator
     def home_free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts by the
         home team.
         """
-        return int(self._home_free_throw_attempts)
+        return self._home_free_throw_attempts
 
-    @property
+    @float_property_decorator
     def home_free_throw_percentage(self):
         """
         Returns a ``float`` of the number of free throws made divided by the
         number of free throw attempts  by the home team.
         """
-        try:
-            return float(self._home_free_throw_percentage)
-        except ValueError:
-            return 0.0
+        return self._home_free_throw_percentage
 
-    @property
+    @int_property_decorator
     def home_offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds by the
         home team.
         """
-        return int(self._home_offensive_rebounds)
+        return self._home_offensive_rebounds
 
-    @property
+    @int_property_decorator
     def home_defensive_rebounds(self):
         """
         Returns an ``int`` of the total number of defensive rebounds by the
         home team.
         """
-        return int(self._home_defensive_rebounds)
+        return self._home_defensive_rebounds
 
-    @property
+    @int_property_decorator
     def home_total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds by the home team.
         """
-        return int(self._home_total_rebounds)
+        return self._home_total_rebounds
 
-    @property
+    @int_property_decorator
     def home_assists(self):
         """
         Returns an ``int`` of the total number of assists by the home team.
         """
-        return int(self._home_assists)
+        return self._home_assists
 
-    @property
+    @int_property_decorator
     def home_steals(self):
         """
         Returns an ``int`` of the total number of steals by the home team.
         """
-        return int(self._home_steals)
+        return self._home_steals
 
-    @property
+    @int_property_decorator
     def home_blocks(self):
         """
         Returns an ``int`` of the total number of blocks by the home team.
         """
-        return int(self._home_blocks)
+        return self._home_blocks
 
-    @property
+    @int_property_decorator
     def home_turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers by the home team.
         """
-        return int(self._home_turnovers)
+        return self._home_turnovers
 
-    @property
+    @int_property_decorator
     def home_personal_fouls(self):
         """
         Returns an ``int`` of the total number of personal fouls by the home
         team.
         """
-        return int(self._home_personal_fouls)
+        return self._home_personal_fouls
 
-    @property
+    @int_property_decorator
     def home_points(self):
         """
         Returns an ``int`` of the number of points the home team scored.
         """
-        return int(self._home_points)
+        return self._home_points
 
-    @property
+    @float_property_decorator
     def home_true_shooting_percentage(self):
         """
         Returns a ``float`` of the home team's true shooting percentage which
         considers free throws, 2-point field goals, and 3-point field goals.
         Percentage ranges from 0-1.
         """
-        return float(self._home_true_shooting_percentage)
+        return self._home_true_shooting_percentage
 
-    @property
+    @float_property_decorator
     def home_effective_field_goal_percentage(self):
         """
         Returns a ``float`` of the home team's field goal percentage while
         giving extra weight to 3-point field goals. Percentage ranges from 0-1.
         """
-        return float(self._home_effective_field_goal_percentage)
+        return self._home_effective_field_goal_percentage
 
-    @property
+    @float_property_decorator
     def home_three_point_attempt_rate(self):
         """
         Returns a ``float`` of the percentage of field goal attempts from
         3-point range by the home team. Percentage ranges from 0-1.
         """
-        return float(self._home_three_point_attempt_rate)
+        return self._home_three_point_attempt_rate
 
-    @property
+    @float_property_decorator
     def home_free_throw_attempt_rate(self):
         """
         Returns a ``float`` of the average number of free throw attempts per
         field goal attempt by the home team.
         """
-        return float(self._home_free_throw_attempt_rate)
+        return self._home_free_throw_attempt_rate
 
-    @property
+    @float_property_decorator
     def home_offensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available offensive rebounds
         the home team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._home_offensive_rebound_percentage)
+        return self._home_offensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def home_defensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available defensive rebounds
         the home team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._home_defensive_rebound_percentage)
+        return self._home_defensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def home_total_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available rebounds the home
         team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._home_total_rebound_percentage)
+        return self._home_total_rebound_percentage
 
-    @property
+    @float_property_decorator
     def home_assist_percentage(self):
         """
         Returns a ``float`` of the percentage of the home team's field goals
         that were assisted. Percentage ranges from 0-100.
         """
-        return float(self._home_assist_percentage)
+        return self._home_assist_percentage
 
-    @property
+    @float_property_decorator
     def home_steal_percentage(self):
         """
         Returns a ``float`` of the percentage of possessions that ended in a
         steal by the home team. Percentage ranges from 0-100.
         """
-        return float(self._home_steal_percentage)
+        return self._home_steal_percentage
 
-    @property
+    @float_property_decorator
     def home_block_percentage(self):
         """
         Returns a ``float`` of the percentage of 2-point field goals that were
         blocked by the home team. Percentage ranges from 0-100.
         """
-        return float(self._home_block_percentage)
+        return self._home_block_percentage
 
-    @property
+    @float_property_decorator
     def home_turnover_percentage(self):
         """
         Returns a ``float`` of the number of times the home team turned the
         ball over per 100 possessions.
         """
-        return float(self._home_turnover_percentage)
+        return self._home_turnover_percentage
 
-    @property
+    @float_property_decorator
     def home_offensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions by the home team.
         """
-        return float(self._home_offensive_rating)
+        return self._home_offensive_rating
 
-    @property
+    @float_property_decorator
     def home_defensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions by the away team.
         """
-        return float(self._home_defensive_rating)
+        return self._home_defensive_rating
 
 
 class Boxscores:

--- a/sportsreference/ncaab/boxscore.py
+++ b/sportsreference/ncaab/boxscore.py
@@ -223,6 +223,10 @@ class Boxscore(object):
         ranking = None
         index = BOXSCORE_ELEMENT_INDEX[field]
         teams_boxscore = boxscore(BOXSCORE_SCHEME[field])
+        # Occasionally, the list of boxscores for the day won't be saved on the
+        # page. If that's the case, return the default ranking.
+        if str(teams_boxscore) == '':
+            return ranking
         team = pq(teams_boxscore[index])
         if 'pollrank' in str(team):
             rank_str = re.findall('\(\d+\)', str(team))

--- a/sportsreference/ncaab/boxscore.py
+++ b/sportsreference/ncaab/boxscore.py
@@ -230,6 +230,36 @@ class Boxscore(object):
                 ranking = int(rank_str[0].replace('(', '').replace(')', ''))
         return ranking
 
+    def _parse_record(self, field, boxscore, index):
+        """
+        Parse each team's record.
+
+        Find the record for both the home and away teams which are listed above
+        the basic boxscore stats tables. Depending on whether or not the
+        advanced stats table is included on the page (generally only for more
+        recent matchups), a blank header is added to the list which should be
+        removed. With all blank headers removed, the home and away team records
+        can be easily parsed by specifying which team is desired.
+
+        Parameters
+        ----------
+        field : string
+            The name of the attribute to parse.
+        boxscore : PyQuery object
+            A PyQuery object containing all of the HTML data from the boxscore.
+        index : int
+            An int of the index to pull the record from, as specified in the
+            BOXSCORE_ELEMENT_INDEX dictionary.
+
+        Returns
+        -------
+        string
+            A string of the team's record in the format 'Team Name (W-L)'.
+        """
+        records = boxscore(BOXSCORE_SCHEME[field]).items()
+        records = [x.text() for x in records if x.text() != '']
+        return records[index]
+
     def _parse_game_data(self, uri):
         """
         Parses a value for every attribute.
@@ -280,6 +310,11 @@ class Boxscore(object):
             index = 0
             if short_field in BOXSCORE_ELEMENT_INDEX.keys():
                 index = BOXSCORE_ELEMENT_INDEX[short_field]
+            if short_field == 'away_record' or \
+               short_field == 'home_record':
+                value = self._parse_record(short_field, boxscore, index)
+                setattr(self, field, value)
+                continue
             value = utils._parse_field(BOXSCORE_SCHEME,
                                        boxscore,
                                        short_field,
@@ -524,7 +559,7 @@ class Boxscore(object):
         try:
             wins, losses = re.findall('\d+', self._away_record)
             return wins
-        except ValueError:
+        except (ValueError, TypeError):
             return 0
 
     @int_property_decorator
@@ -536,7 +571,7 @@ class Boxscore(object):
         try:
             wins, losses = re.findall('\d+', self._away_record)
             return losses
-        except ValueError:
+        except (ValueError, TypeError):
             return 0
 
     @int_property_decorator
@@ -847,7 +882,7 @@ class Boxscore(object):
         try:
             wins, losses = re.findall('\d+', self._home_record)
             return wins
-        except ValueError:
+        except (ValueError, TypeError):
             return 0
 
     @int_property_decorator
@@ -859,7 +894,7 @@ class Boxscore(object):
         try:
             wins, losses = re.findall('\d+', self._home_record)
             return losses
-        except ValueError:
+        except (ValueError, TypeError):
             return 0
 
     @int_property_decorator

--- a/sportsreference/ncaab/constants.py
+++ b/sportsreference/ncaab/constants.py
@@ -198,7 +198,7 @@ BOXSCORE_ELEMENT_INDEX = {
     'location': 1,
     'away_ranking': 0,
     'home_ranking': 1,
-    'home_record': 2,
+    'home_record': 1,
     'home_minutes_played': 1,
     'home_field_goals': 1,
     'home_field_goal_attempts': 1,

--- a/sportsreference/ncaab/roster.py
+++ b/sportsreference/ncaab/roster.py
@@ -27,8 +27,8 @@ def int_property_decorator(func):
         try:
             return int(value)
         except ValueError:
-            # If there is no value, default to 0
-            return 0
+            # If there is no value, default to None
+            return None
     return wrapper
 
 
@@ -42,8 +42,8 @@ def float_property_decorator(func):
         try:
             return float(value)
         except ValueError:
-            # If there is no value, default to 0.0
-            return 0.0
+            # If there is no value, default to None
+            return None
     return wrapper
 
 

--- a/sportsreference/ncaab/roster.py
+++ b/sportsreference/ncaab/roster.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+from functools import wraps
 from pyquery import PyQuery as pq
 from .. import utils
 from .constants import PLAYER_SCHEME, PLAYER_URL
@@ -18,6 +19,7 @@ def cleanup(prop):
 
 def int_property_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
@@ -32,6 +34,7 @@ def int_property_decorator(func):
 
 def float_property_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
@@ -46,6 +49,7 @@ def float_property_decorator(func):
 
 def most_recent_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         season = args[0]._most_recent_season
         seasons = args[0]._season

--- a/sportsreference/ncaab/schedule.py
+++ b/sportsreference/ncaab/schedule.py
@@ -369,7 +369,7 @@ class Game(object):
         return self._arena
 
 
-class Schedule:
+class Schedule(object):
     """
     An object of the given team's schedule.
 
@@ -488,7 +488,11 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe)
+            df = game.dataframe
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)
 
     @property
@@ -502,5 +506,9 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe_extended)
+            df = game.dataframe_extended
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)

--- a/sportsreference/ncaab/schedule.py
+++ b/sportsreference/ncaab/schedule.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+from ..decorators import int_property_decorator
 from .constants import (SCHEDULE_SCHEME,
                         SCHEDULE_URL,
                         NCAA_TOURNAMENT,
@@ -174,13 +175,13 @@ class Game(object):
             return None
         return self.boxscore.dataframe
 
-    @property
+    @int_property_decorator
     def game(self):
         """
         Returns an ``int`` of the game's position in the season. The first game
         of the season returns 1.
         """
-        return int(self._game)
+        return self._game
 
     @property
     def date(self):
@@ -303,19 +304,21 @@ class Game(object):
             return WIN
         return LOSS
 
-    @property
+    @int_property_decorator
     def points_for(self):
         """
-        Returns the number of points the team scored during the game.
+        Returns an ``int`` of the number of points the team scored during the
+        game.
         """
-        return int(self._points_for)
+        return self._points_for
 
-    @property
+    @int_property_decorator
     def points_against(self):
         """
-        Returns the number of points the team allowed during the game.
+        Returns an ``int`` of the number of points the team allowed during the
+        game.
         """
-        return int(self._points_against)
+        return self._points_against
 
     @property
     def overtimes(self):
@@ -323,7 +326,7 @@ class Game(object):
         Returns an ``int`` of the number of overtimes that were played during
         the game and 0 if the game finished at the end of regulation time.
         """
-        if self._overtimes == '':
+        if self._overtimes == '' or self._overtimes is None:
             return 0
         if self._overtimes.lower() == 'ot':
             return 1
@@ -333,21 +336,21 @@ class Game(object):
         except (ValueError, IndexError):
             return 0
 
-    @property
+    @int_property_decorator
     def season_wins(self):
         """
         Returns an ``int`` of the number of games the team has won after the
         conclusion of the requested game.
         """
-        return int(self._season_wins)
+        return self._season_wins
 
-    @property
+    @int_property_decorator
     def season_losses(self):
         """
         Returns an ``int`` of the number of games the team has lost after the
         conclusion of the requested game.
         """
-        return int(self._season_losses)
+        return self._season_losses
 
     @property
     def streak(self):

--- a/sportsreference/ncaab/teams.py
+++ b/sportsreference/ncaab/teams.py
@@ -6,6 +6,7 @@ from .constants import (ADVANCED_OPPONENT_STATS_URL,
                         BASIC_STATS_URL,
                         PARSING_SCHEME)
 from pyquery import PyQuery as pq
+from ..decorators import float_property_decorator, int_property_decorator
 from .. import utils
 from .conferences import Conferences
 from .schedule import Schedule
@@ -287,39 +288,39 @@ class Team(object):
         """
         return self._name
 
-    @property
+    @int_property_decorator
     def games_played(self):
         """
         Returns an ``int`` of the total number of games the team has played
         during the season.
         """
-        return int(self._games_played)
+        return self._games_played
 
-    @property
+    @int_property_decorator
     def wins(self):
         """
         Returns an ``int`` of the total number of games the team won during the
         season.
         """
-        return int(self._wins)
+        return self._wins
 
-    @property
+    @int_property_decorator
     def losses(self):
         """
         Returns an ``int`` of the total number of games the team lost during
         the season.
         """
-        return int(self._losses)
+        return self._losses
 
-    @property
+    @float_property_decorator
     def win_percentage(self):
         """
         Returns a ``float`` of the number of wins divided by the number of
         games played during the season. Percentage ranges from 0-1.
         """
-        return float(self._win_percentage)
+        return self._win_percentage
 
-    @property
+    @float_property_decorator
     def simple_rating_system(self):
         """
         Returns a ``float`` of the team's average point differential compared
@@ -327,9 +328,9 @@ class Team(object):
         average team is denoted with 0.0. Negative numbers are comparatively
         worse than average.
         """
-        return float(self._simple_rating_system)
+        return self._simple_rating_system
 
-    @property
+    @float_property_decorator
     def strength_of_schedule(self):
         """
         Returns a ``float`` of the team's strength of schedule based on the
@@ -337,105 +338,105 @@ class Team(object):
         denoted with 0.0. Negative numbers are comparatively easier than
         average.
         """
-        return float(self._strength_of_schedule)
+        return self._strength_of_schedule
 
-    @property
+    @int_property_decorator
     def conference_wins(self):
         """
         Returns an ``int`` of the total number of conference games the team won
         during the season.
         """
-        return int(self._conference_wins)
+        return self._conference_wins
 
-    @property
+    @int_property_decorator
     def conference_losses(self):
         """
         Returns an ``int`` of the total number of conference games the team
         lost during the season.
         """
-        return int(self._conference_losses)
+        return self._conference_losses
 
-    @property
+    @int_property_decorator
     def home_wins(self):
         """
         Returns an ``int`` of the total number of home games the team won
         during the season.
         """
-        return int(self._home_wins)
+        return self._home_wins
 
-    @property
+    @int_property_decorator
     def home_losses(self):
         """
         Returns an ``int`` of the total number of home games the team lost
         during the season.
         """
-        return int(self._home_losses)
+        return self._home_losses
 
-    @property
+    @int_property_decorator
     def away_wins(self):
         """
         Returns an ``int`` of the total number of away games the team won
         during the season.
         """
-        return int(self._away_wins)
+        return self._away_wins
 
-    @property
+    @int_property_decorator
     def away_losses(self):
         """
         Returns an ``int`` of the total number of away games the team lost
         during the season.
         """
-        return int(self._away_losses)
+        return self._away_losses
 
-    @property
+    @int_property_decorator
     def points(self):
         """
         Returns an ``int`` of the total number of points the team scored during
         the season.
         """
-        return int(self._points)
+        return self._points
 
-    @property
+    @int_property_decorator
     def opp_points(self):
         """
         Returns an ``int`` of the total number of points opponents have scored
         during the season.
         """
-        return int(self._opp_points)
+        return self._opp_points
 
-    @property
+    @int_property_decorator
     def minutes_played(self):
         """
         Returns an ``int`` of the total number of minutes played by the team
         during the season.
         """
-        return int(self._minutes_played)
+        return self._minutes_played
 
-    @property
+    @int_property_decorator
     def field_goals(self):
         """
         Returns an ``int`` of the total number of field goals made during the
         season.
         """
-        return int(self._field_goals)
+        return self._field_goals
 
-    @property
+    @int_property_decorator
     def field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goal attempts during
         the season.
         """
-        return int(self._field_goal_attempts)
+        return self._field_goal_attempts
 
-    @property
+    @float_property_decorator
     def field_goal_percentage(self):
         """
         Returns a ``float`` of the number of field goals made divided by the
         total number of field goal attempts. Percentage ranges from 0-1.
         """
-        return float(self._field_goal_percentage)
+        return self._field_goal_percentage
 
-    @property
+    @int_property_decorator
     def two_point_field_goals(self):
         """
         Returns an ``int`` of the total number of two point field goals made
@@ -443,7 +444,7 @@ class Team(object):
         """
         return self.field_goals - self.three_point_field_goals
 
-    @property
+    @int_property_decorator
     def two_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of two point field goal attempts
@@ -451,7 +452,7 @@ class Team(object):
         """
         return self.field_goal_attempts - self.three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def two_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of two point field goals made divided
@@ -465,64 +466,64 @@ class Team(object):
         except ZeroDivisionError:
             return 0.0
 
-    @property
+    @int_property_decorator
     def three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals made
         during the season.
         """
-        return int(self._three_point_field_goals)
+        return self._three_point_field_goals
 
-    @property
+    @int_property_decorator
     def three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goal
         attempts during the season.
         """
-        return int(self._three_point_field_goal_attempts)
+        return self._three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of three point field goals made
         divided by the number of three point field goal attempts. Percentage
         ranges from 0-1.
         """
-        return float(self._three_point_field_goal_percentage)
+        return self._three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made during the
         season.
         """
-        return int(self._free_throws)
+        return self._free_throws
 
-    @property
+    @int_property_decorator
     def free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts during
         the season.
         """
-        return int(self._free_throw_attempts)
+        return self._free_throw_attempts
 
-    @property
+    @float_property_decorator
     def free_throw_percentage(self):
         """
         Returns a ``float`` of the number of free throws made divided by the
         number of free throw attempts during the season.
         """
-        return float(self._free_throw_percentage)
+        return self._free_throw_percentage
 
-    @property
+    @int_property_decorator
     def offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds during the
         season.
         """
-        return int(self._offensive_rebounds)
+        return self._offensive_rebounds
 
-    @property
+    @int_property_decorator
     def defensive_rebounds(self):
         """
         Returns an ``int`` of the total number of defensive rebounds during the
@@ -530,75 +531,75 @@ class Team(object):
         """
         return self.total_rebounds - self.offensive_rebounds
 
-    @property
+    @int_property_decorator
     def total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds during the season.
         """
-        return int(self._total_rebounds)
+        return self._total_rebounds
 
-    @property
+    @int_property_decorator
     def assists(self):
         """
         Returns an ``int`` of the total number of assists during the season.
         """
-        return int(self._assists)
+        return self._assists
 
-    @property
+    @int_property_decorator
     def steals(self):
         """
         Returns an ``int`` of the total number of steals during the season.
         """
-        return int(self._steals)
+        return self._steals
 
-    @property
+    @int_property_decorator
     def blocks(self):
         """
         Returns an ``int`` of the total number of blocks during the season.
         """
-        return int(self._blocks)
+        return self._blocks
 
-    @property
+    @int_property_decorator
     def turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers during the season.
         """
-        return int(self._turnovers)
+        return self._turnovers
 
-    @property
+    @int_property_decorator
     def personal_fouls(self):
         """
         Returns an ``int`` of the total number of personal fouls during the
         season.
         """
-        return int(self._personal_fouls)
+        return self._personal_fouls
 
-    @property
+    @int_property_decorator
     def opp_field_goals(self):
         """
         Returns an ``int`` of the total number of field goals made during the
         season by opponents.
         """
-        return int(self._opp_field_goals)
+        return self._opp_field_goals
 
-    @property
+    @int_property_decorator
     def opp_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of field goal attempts during
         the season by opponents.
         """
-        return int(self._opp_field_goal_attempts)
+        return self._opp_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def opp_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of field goals made divided by the
         total number of field goal attempts by opponents. Percentage ranges
         from 0-1.
         """
-        return float(self._opp_field_goal_percentage)
+        return self._opp_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def opp_two_point_field_goals(self):
         """
         Returns an ``int`` of the total number of two point field goals made
@@ -606,7 +607,7 @@ class Team(object):
         """
         return self.opp_field_goals - self.opp_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def opp_two_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of two point field goal attempts
@@ -615,7 +616,7 @@ class Team(object):
         return self.opp_field_goal_attempts - \
             self.opp_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def opp_two_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of two point field goals made divided
@@ -629,64 +630,64 @@ class Team(object):
         except ZeroDivisionError:
             return 0.0
 
-    @property
+    @int_property_decorator
     def opp_three_point_field_goals(self):
         """
         Returns an ``int`` of the total number of three point field goals made
         during the season by opponents.
         """
-        return int(self._opp_three_point_field_goals)
+        return self._opp_three_point_field_goals
 
-    @property
+    @int_property_decorator
     def opp_three_point_field_goal_attempts(self):
         """
         Returns an ``int`` of the total number of three point field goal
         attempts during the season by opponents.
         """
-        return int(self._opp_three_point_field_goal_attempts)
+        return self._opp_three_point_field_goal_attempts
 
-    @property
+    @float_property_decorator
     def opp_three_point_field_goal_percentage(self):
         """
         Returns a ``float`` of the number of three point field goals made
         divided by the number of three point field goal attempts by opponents.
         Percentage ranges from 0-1.
         """
-        return float(self._opp_three_point_field_goal_percentage)
+        return self._opp_three_point_field_goal_percentage
 
-    @property
+    @int_property_decorator
     def opp_free_throws(self):
         """
         Returns an ``int`` of the total number of free throws made during the
         season by opponents.
         """
-        return int(self._opp_free_throws)
+        return self._opp_free_throws
 
-    @property
+    @int_property_decorator
     def opp_free_throw_attempts(self):
         """
         Returns an ``int`` of the total number of free throw attempts during
         the season by opponents.
         """
-        return int(self._opp_free_throw_attempts)
+        return self._opp_free_throw_attempts
 
-    @property
+    @float_property_decorator
     def opp_free_throw_percentage(self):
         """
         Returns a ``float`` of the number of free throws made divided by the
         number of free throw attempts during the season by opponents.
         """
-        return float(self._opp_free_throw_percentage)
+        return self._opp_free_throw_percentage
 
-    @property
+    @int_property_decorator
     def opp_offensive_rebounds(self):
         """
         Returns an ``int`` of the total number of offensive rebounds during the
         season by opponents.
         """
-        return int(self._opp_offensive_rebounds)
+        return self._opp_offensive_rebounds
 
-    @property
+    @int_property_decorator
     def opp_defensive_rebounds(self):
         """
         Returns an ``int`` of the total number of defensive rebounds during the
@@ -694,71 +695,71 @@ class Team(object):
         """
         return self.opp_total_rebounds - self.opp_offensive_rebounds
 
-    @property
+    @int_property_decorator
     def opp_total_rebounds(self):
         """
         Returns an ``int`` of the total number of rebounds during the season by
         opponents.
         """
-        return int(self._opp_total_rebounds)
+        return self._opp_total_rebounds
 
-    @property
+    @int_property_decorator
     def opp_assists(self):
         """
         Returns an ``int`` of the total number of assists during the season by
         opponents.
         """
-        return int(self._opp_assists)
+        return self._opp_assists
 
-    @property
+    @int_property_decorator
     def opp_steals(self):
         """
         Returns an ``int`` of the total number of steals during the season by
         opponents.
         """
-        return int(self._opp_steals)
+        return self._opp_steals
 
-    @property
+    @int_property_decorator
     def opp_blocks(self):
         """
         Returns an ``int`` of the total number of blocks during the season by
         opponents.
         """
-        return int(self._opp_blocks)
+        return self._opp_blocks
 
-    @property
+    @int_property_decorator
     def opp_turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers during the season
         by opponents.
         """
-        return int(self._opp_turnovers)
+        return self._opp_turnovers
 
-    @property
+    @int_property_decorator
     def opp_personal_fouls(self):
         """
         Returns an ``int`` of the total number of personal fouls during the
         season by opponents.
         """
-        return int(self._opp_personal_fouls)
+        return self._opp_personal_fouls
 
-    @property
+    @float_property_decorator
     def pace(self):
         """
         Returns a ``float`` of the average number of possessions per 40
         minutes.
         """
-        return float(self._pace)
+        return self._pace
 
-    @property
+    @float_property_decorator
     def offensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
         possessions.
         """
-        return float(self._offensive_rating)
+        return self._offensive_rating
 
-    @property
+    @float_property_decorator
     def net_rating(self):
         """
         Returns a ``float`` of the net team rating which is equivalent to the
@@ -768,98 +769,98 @@ class Team(object):
         """
         return self.offensive_rating - self.opp_offensive_rating
 
-    @property
+    @float_property_decorator
     def free_throw_attempt_rate(self):
         """
         Returns a ``float`` of the average number of free throw attempts per
         field goal attempt.
         """
-        return float(self._free_throw_attempt_rate)
+        return self._free_throw_attempt_rate
 
-    @property
+    @float_property_decorator
     def three_point_attempt_rate(self):
         """
         Returns a ``float`` of the percentage of field goal attempts from
         3-point range. Percentage ranges from 0-1.
         """
-        return float(self._three_point_attempt_rate)
+        return self._three_point_attempt_rate
 
-    @property
+    @float_property_decorator
     def true_shooting_percentage(self):
         """
         Returns a ``float`` of the team's true shooting percentage which
         considers free throws, 2-point field goals, and 3-point field goals.
         Percentage ranges from 0-1.
         """
-        return float(self._true_shooting_percentage)
+        return self._true_shooting_percentage
 
-    @property
+    @float_property_decorator
     def total_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available rebounds a team
         grabbed.
         Percentage ranges from 0-100.
         """
-        return float(self._total_rebound_percentage)
+        return self._total_rebound_percentage
 
-    @property
+    @float_property_decorator
     def assist_percentage(self):
         """
         Returns a ``float`` of the percentage of field goals that were
         assisted.
         Percentage ranges from 0-100.
         """
-        return float(self._assist_percentage)
+        return self._assist_percentage
 
-    @property
+    @float_property_decorator
     def steal_percentage(self):
         """
         Returns a ``float`` of the percentage of opponent possessions that
         ended in a steal. Percentage ranges from 0-100.
         """
-        return float(self._steal_percentage)
+        return self._steal_percentage
 
-    @property
+    @float_property_decorator
     def block_percentage(self):
         """
         Returns a ``float`` of the percentage of 2-point field goals by the
         opponent that were blocked. Percentage ranges from 0-100.
         """
-        return float(self._block_percentage)
+        return self._block_percentage
 
-    @property
+    @float_property_decorator
     def effective_field_goal_percentage(self):
         """
         Returns a ``float`` of the field goal percentage while giving extra
         weight to 3-point field goals. Percentage ranges from 0-1.
         """
-        return float(self._effective_field_goal_percentage)
+        return self._effective_field_goal_percentage
 
-    @property
+    @float_property_decorator
     def turnover_percentage(self):
         """
         Returns a ``float`` of the number of times the team turned the ball
         over per 100 possessions.
         """
-        return float(self._turnover_percentage)
+        return self._turnover_percentage
 
-    @property
+    @float_property_decorator
     def offensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available offensive rebounds a
         team grabbed. Percentage ranges from 0-100.
         """
-        return float(self._offensive_rebound_percentage)
+        return self._offensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def free_throws_per_field_goal_attempt(self):
         """
         Returns a ``float`` of the number of free throws per field goal
         attempt.
         """
-        return float(self._free_throws_per_field_goal_attempt)
+        return self._free_throws_per_field_goal_attempt
 
-    @property
+    @float_property_decorator
     def opp_offensive_rating(self):
         """
         Returns a ``float`` of the average number of points scored per 100
@@ -867,96 +868,96 @@ class Team(object):
         rating as it is the number of points the team allows per 100
         possessions by the opponent.
         """
-        return float(self._opp_offensive_rating)
+        return self._opp_offensive_rating
 
-    @property
+    @float_property_decorator
     def opp_free_throw_attempt_rate(self):
         """
         Returns a ``float`` of the average number of free throw attempts per
         field goal attempt by the opponent.
         """
-        return float(self._opp_free_throw_attempt_rate)
+        return self._opp_free_throw_attempt_rate
 
-    @property
+    @float_property_decorator
     def opp_three_point_attempt_rate(self):
         """
         Returns a ``float`` of the percentage of field goal attempts from
         3-point range by the opponent. Percentage ranges from 0-1.
         """
-        return float(self._opp_three_point_attempt_rate)
+        return self._opp_three_point_attempt_rate
 
-    @property
+    @float_property_decorator
     def opp_true_shooting_percentage(self):
         """
         Returns a ``float`` of the opponent's true shooting percentage which
         considers free throws, 2-point field goals, and 3-point field goals.
         Percentage ranges from 0-1.
         """
-        return float(self._opp_true_shooting_percentage)
+        return self._opp_true_shooting_percentage
 
-    @property
+    @float_property_decorator
     def opp_total_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available rebounds the
         opponent grabbed. Percentage ranges from 0-100.
         """
-        return float(self._opp_total_rebound_percentage)
+        return self._opp_total_rebound_percentage
 
-    @property
+    @float_property_decorator
     def opp_assist_percentage(self):
         """
         Returns a ``float`` of the percentage of the opponent's field goals
         that were assisted. Percentage ranges from 0-100.
         """
-        return float(self._opp_assist_percentage)
+        return self._opp_assist_percentage
 
-    @property
+    @float_property_decorator
     def opp_steal_percentage(self):
         """
         Returns a ``float`` of the percentage of possessions that ended in a
         steal by the opponent. Percentage ranges from 0-100.
         """
-        return float(self._opp_steal_percentage)
+        return self._opp_steal_percentage
 
-    @property
+    @float_property_decorator
     def opp_block_percentage(self):
         """
         Returns a ``float`` of the percentage of 2-point field goals that were
         blocked by the opponent. Percentage ranges from 0-100.
         """
-        return float(self._opp_block_percentage)
+        return self._opp_block_percentage
 
-    @property
+    @float_property_decorator
     def opp_effective_field_goal_percentage(self):
         """
         Returns a ``float`` of the opponent's field goal percentage while
         giving extra weight to 3-point field goals. Percentage ranges from 0-1.
         """
-        return float(self._opp_effective_field_goal_percentage)
+        return self._opp_effective_field_goal_percentage
 
-    @property
+    @float_property_decorator
     def opp_turnover_percentage(self):
         """
         Returns a ``float`` of the number of times the opponent turned the ball
         over per 100 possessions.
         """
-        return float(self._opp_turnover_percentage)
+        return self._opp_turnover_percentage
 
-    @property
+    @float_property_decorator
     def opp_offensive_rebound_percentage(self):
         """
         Returns a ``float`` of the percentage of available offensive rebounds
         the opponent grabbed. Percentage ranges from 0-100.
         """
-        return float(self._opp_offensive_rebound_percentage)
+        return self._opp_offensive_rebound_percentage
 
-    @property
+    @float_property_decorator
     def opp_free_throws_per_field_goal_attempt(self):
         """
         Returns a ``float`` of the number of free throws per field goal attempt
         by the opponent.
         """
-        return float(self._opp_free_throws_per_field_goal_attempt)
+        return self._opp_free_throws_per_field_goal_attempt
 
 
 class Teams:

--- a/sportsreference/ncaaf/boxscore.py
+++ b/sportsreference/ncaaf/boxscore.py
@@ -2,12 +2,34 @@ import pandas as pd
 import re
 from pyquery import PyQuery as pq
 from .. import utils
+from ..decorators import int_property_decorator
 from .constants import (BOXSCORE_ELEMENT_INDEX,
+                        BOXSCORE_ELEMENT_SUB_INDEX,
                         BOXSCORE_SCHEME,
                         BOXSCORE_URL,
                         BOXSCORES_URL)
 from sportsreference import utils
 from sportsreference.constants import AWAY, HOME
+
+
+def ncaaf_int_property_sub_index(func):
+    # Decorator dedicated to properties with sub-indices, such as pass yards
+    # which is indexed within a table cell but also has multiple other values
+    # in that same cell that need to be ignored.
+    @property
+    def wrapper(*args):
+        value = func(*args)
+        # Equivalent to the calling property's method name
+        field = func.__name__
+        try:
+            field_items = value.replace('--', '-').split('-')
+        except AttributeError:
+            return None
+        try:
+            return int(field_items[BOXSCORE_ELEMENT_SUB_INDEX[field]])
+        except (TypeError, ValueError, IndexError):
+            return None
+    return wrapper
 
 
 class Boxscore(object):
@@ -359,295 +381,245 @@ class Boxscore(object):
             return self._home_name.text()
         return utils._parse_abbreviation(self._home_name)
 
-    @property
+    @int_property_decorator
     def away_points(self):
         """
         Returns an ``int`` of the number of points the away team scored.
         """
-        return int(self._away_points)
+        return self._away_points
 
-    @property
+    @int_property_decorator
     def away_first_downs(self):
         """
         Returns an ``int`` of the number of first downs the away team gained.
         """
-        return int(self._away_first_downs)
+        return self._away_first_downs
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_rush_attempts(self):
         """
         Returns an ``int`` of the number of rushing plays the away team made.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._away_rush_attempts.replace('--', '-').split('-')
-        return int(rush_info[0])
+        return self._away_rush_attempts
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_rush_yards(self):
         """
         Returns an ``int`` of the number of rushing yards the away team gained.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._away_rush_yards.replace('--', '-').split('-')
-        return int(rush_info[1])
+        return self._away_rush_yards
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_rush_touchdowns(self):
         """
         Returns an ``int`` of the number of rushing touchdowns the away team
         scored.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._away_rush_touchdowns.replace('--', '-').split('-')
-        return int(rush_info[2])
+        return self._away_rush_touchdowns
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_pass_completions(self):
         """
         Returns an ``int`` of the number of completed passes the away team
         made.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_pass_completions.replace('--', '-').split('-')
-        return int(pass_info[0])
+        return self._away_pass_completions
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_pass_attempts(self):
         """
         Returns an ``int`` of the number of passes that were thrown by the away
         team.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_pass_attempts.replace('--', '-').split('-')
-        return int(pass_info[1])
+        return self._away_pass_attempts
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_pass_yards(self):
         """
         Returns an ``int`` of the number of passing yards the away team gained.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_pass_yards.replace('--', '-').split('-')
-        return int(pass_info[2])
+        return self._away_pass_yards
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_pass_touchdowns(self):
         """
         Returns an ``int`` of the number of passing touchdowns the away team
         scored.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_pass_touchdowns.replace('--', '-').split('-')
-        return int(pass_info[3])
+        return self._away_pass_touchdowns
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_interceptions(self):
         """
         Returns an ``int`` of the number of interceptions the away team threw.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_interceptions.replace('--', '-').split('-')
-        return int(pass_info[4])
+        return self._away_interceptions
 
-    @property
+    @int_property_decorator
     def away_total_yards(self):
         """
         Returns an ``int`` of the total number of yards the away team gained.
         """
-        return int(self._away_total_yards)
+        return self._away_total_yards
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_fumbles(self):
         """
         Returns an ``int`` of the number of times the away team fumbled the
         ball.
         """
-        # Fumble info is in the format 'Fumbles-Lost'
-        fumble_info = self._away_fumbles.replace('--', '-').split('-')
-        return int(fumble_info[0])
+        return self._away_fumbles
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_fumbles_lost(self):
         """
         Returns an ``int`` of the number of times the away team turned the ball
         over as the result of a fumble.
         """
-        # Fumble info is in the format 'Fumbles-Lost'
-        fumble_info = self._away_fumbles.replace('--', '-').split('-')
-        return int(fumble_info[1])
+        return self._away_fumbles
 
-    @property
+    @int_property_decorator
     def away_turnovers(self):
         """
         Returns an ``int`` of the number of times the away team turned the ball
         over.
         """
-        return int(self._away_turnovers)
+        return self._away_turnovers
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_penalties(self):
         """
         Returns an ``int`` of the number of penalties called on the away team.
         """
-        # Penalties info is in the format 'Penalties-Yards'
-        penalties_info = self._away_penalties.replace('--', '-').split('-')
-        return int(penalties_info[0])
+        return self._away_penalties
 
-    @property
+    @ncaaf_int_property_sub_index
     def away_yards_from_penalties(self):
         """
         Returns an ``int`` of the number of yards gifted as a result of
         penalties called on the away team.
         """
-        # Penalties info is in the format 'Penalties-Yards'
-        penalties_info = self._away_yards_from_penalties.replace('--', '-')
-        penalties_info = penalties_info.split('-')
-        return int(penalties_info[1])
+        return self._away_yards_from_penalties
 
-    @property
+    @int_property_decorator
     def home_points(self):
         """
         Returns an ``int`` of the number of points the home team scored.
         """
-        return int(self._home_points)
+        return self._home_points
 
-    @property
+    @int_property_decorator
     def home_first_downs(self):
         """
         Returns an ``int`` of the number of first downs the home team gained.
         """
-        return int(self._home_first_downs)
+        return self._home_first_downs
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_rush_attempts(self):
         """
         Returns an ``int`` of the number of rushing plays the home team made.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._home_rush_attempts.replace('--', '-').split('-')
-        return int(rush_info[0])
+        return self._home_rush_attempts
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_rush_yards(self):
         """
         Returns an ``int`` of the number of rushing yards the home team gained.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._home_rush_yards.replace('--', '-').split('-')
-        return int(rush_info[1])
+        return self._home_rush_yards
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_rush_touchdowns(self):
         """
         Returns an ``int`` of the number of rushing touchdowns the home team
         scored.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._home_rush_touchdowns.replace('--', '-').split('-')
-        return int(rush_info[2])
+        return self._home_rush_touchdowns
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_pass_completions(self):
         """
         Returns an ``int`` of the number of completed passes the home team
         made.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_completions.replace('--', '-').split('-')
-        return int(pass_info[0])
+        return self._home_pass_completions
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_pass_attempts(self):
         """
         Returns an ``int`` of the number of passes that were thrown by the home
         team.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_attempts.replace('--', '-').split('-')
-        return int(pass_info[1])
+        return self._home_pass_attempts
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_pass_yards(self):
         """
         Returns an ``int`` of the number of passing yards the home team gained.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_yards.replace('--', '-').split('-')
-        return int(pass_info[2])
+        return self._home_pass_yards
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_pass_touchdowns(self):
         """
         Returns an ``int`` of the number of passing touchdowns the home team
         scored.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_touchdowns.replace('--', '-').split('-')
-        return int(pass_info[3])
+        return self._home_pass_touchdowns
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_interceptions(self):
         """
         Returns an ``int`` of the number of interceptions the home team threw.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_touchdowns.replace('--', '-').split('-')
-        return int(pass_info[4])
+        return self._home_pass_touchdowns
 
-    @property
+    @int_property_decorator
     def home_total_yards(self):
         """
         Returns an ``int`` of the total number of yards the home team gained.
         """
-        return int(self._home_total_yards)
+        return self._home_total_yards
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_fumbles(self):
         """
         Returns an ``int`` of the number of times the home team fumbled the
         ball.
         """
-        # Fumble info is in the format 'Fumbles-Lost'
-        fumble_info = self._home_fumbles.replace('--', '-').split('-')
-        return int(fumble_info[0])
+        return self._home_fumbles
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_fumbles_lost(self):
         """
         Returns an ``int`` of the number of times the home team turned the ball
         over as the result of a fumble.
         """
-        # Fumble info is in the format 'Fumbles-Lost'
-        fumble_info = self._home_fumbles_lost.replace('--', '-').split('-')
-        return int(fumble_info[1])
+        return self._home_fumbles_lost
 
-    @property
+    @int_property_decorator
     def home_turnovers(self):
         """
         Returns an ``int`` of the number of times the home team turned the ball
         over.
         """
-        return int(self._home_turnovers)
+        return self._home_turnovers
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_penalties(self):
         """
         Returns an ``int`` of the number of penalties called on the home team.
         """
-        # Penalties info is in the format 'Penalties-Yards'
-        penalties_info = self._home_penalties.replace('--', '-').split('-')
-        return int(penalties_info[0])
+        return self._home_penalties
 
-    @property
+    @ncaaf_int_property_sub_index
     def home_yards_from_penalties(self):
         """
         Returns an ``int`` of the number of yards gifted as a result of
         penalties called on the home team.
         """
-        # Penalties info is in the format 'Penalties-Yards'
-        penalties_info = self._home_yards_from_penalties.replace('--', '-')
-        penalties_info = penalties_info.split('-')
-        return int(penalties_info[1])
+        return self._home_yards_from_penalties
 
 
 class Boxscores:

--- a/sportsreference/ncaaf/boxscore.py
+++ b/sportsreference/ncaaf/boxscore.py
@@ -8,6 +8,7 @@ from .constants import (BOXSCORE_ELEMENT_INDEX,
                         BOXSCORE_SCHEME,
                         BOXSCORE_URL,
                         BOXSCORES_URL)
+from functools import wraps
 from sportsreference import utils
 from sportsreference.constants import AWAY, HOME
 
@@ -17,6 +18,7 @@ def ncaaf_int_property_sub_index(func):
     # which is indexed within a table cell but also has multiple other values
     # in that same cell that need to be ignored.
     @property
+    @wraps(func)
     def wrapper(*args):
         value = func(*args)
         # Equivalent to the calling property's method name

--- a/sportsreference/ncaaf/constants.py
+++ b/sportsreference/ncaaf/constants.py
@@ -193,6 +193,34 @@ BOXSCORE_ELEMENT_INDEX = {
     'home_yards_from_penalties': 6
 }
 
+# Designates the index of the item within the requested tag
+BOXSCORE_ELEMENT_SUB_INDEX = {
+    'away_rush_attempts': 0,
+    'away_rush_yards': 1,
+    'away_rush_touchdowns': 2,
+    'away_pass_completions': 0,
+    'away_pass_attempts': 1,
+    'away_pass_yards': 2,
+    'away_pass_touchdowns': 3,
+    'away_interceptions': 4,
+    'away_fumbles': 0,
+    'away_fumbles_lost': 1,
+    'away_penalties': 0,
+    'away_yards_from_penalties': 1,
+    'home_rush_attempts': 0,
+    'home_rush_yards': 1,
+    'home_rush_touchdowns': 2,
+    'home_pass_completions': 0,
+    'home_pass_attempts': 1,
+    'home_pass_yards': 2,
+    'home_pass_touchdowns': 3,
+    'home_interceptions': 4,
+    'home_fumbles': 0,
+    'home_fumbles_lost': 1,
+    'home_penalties': 0,
+    'home_yards_from_penalties': 1
+}
+
 SEASON_PAGE_URL = 'http://www.sports-reference.com/cfb/years/%s-standings.html'
 
 OFFENSIVE_STATS_URL = ('https://www.sports-reference.com/cfb/years/'

--- a/sportsreference/ncaaf/schedule.py
+++ b/sportsreference/ncaaf/schedule.py
@@ -324,7 +324,7 @@ class Game(object):
         return self._streak
 
 
-class Schedule:
+class Schedule(object):
     """
     An object of the given team's schedule.
 
@@ -443,7 +443,11 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe)
+            df = game.dataframe
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)
 
     @property
@@ -457,5 +461,9 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe_extended)
+            df = game.dataframe_extended
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)

--- a/sportsreference/ncaaf/schedule.py
+++ b/sportsreference/ncaaf/schedule.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+from ..decorators import int_property_decorator
 from .constants import (SCHEDULE_SCHEME,
                         SCHEDULE_URL)
 from datetime import datetime
@@ -221,7 +222,7 @@ class Game(object):
             return AWAY
         return HOME
 
-    @property
+    @int_property_decorator
     def rank(self):
         """
         Returns an ``int`` of the team's rank at the time the game was played.
@@ -229,9 +230,9 @@ class Game(object):
         rank = re.findall('\d+', self._rank)
         if len(rank) == 0:
             return None
-        return int(rank[0])
+        return rank[0]
 
-    @property
+    @int_property_decorator
     def opponent_rank(self):
         """
         Returns an ``int`` of the opponent's rank at the time the game was
@@ -240,7 +241,7 @@ class Game(object):
         rank = re.findall('\d+', self._opponent_name)
         if len(rank) == 0:
             return None
-        return int(rank[0])
+        return rank[0]
 
     @property
     def opponent_name(self):
@@ -280,37 +281,37 @@ class Game(object):
             return LOSS
         return WIN
 
-    @property
+    @int_property_decorator
     def points_for(self):
         """
         Returns an ``int`` of the number of points the team scored during the
         game.
         """
-        return int(self._points_for)
+        return self._points_for
 
-    @property
+    @int_property_decorator
     def points_against(self):
         """
         Returns an ``int`` of the number of points the team allowed during the
         game.
         """
-        return int(self._points_against)
+        return self._points_against
 
-    @property
+    @int_property_decorator
     def wins(self):
         """
         Returns an ``int`` of the number of games the team has won so far in
         the season at the conclusion of the requested game.
         """
-        return int(self._wins)
+        return self._wins
 
-    @property
+    @int_property_decorator
     def losses(self):
         """
         Returns an ``int`` of the number of games the team has lost so far in
         the season at the conclusion of the requested game.
         """
-        return int(self._losses)
+        return self._losses
 
     @property
     def streak(self):

--- a/sportsreference/ncaaf/teams.py
+++ b/sportsreference/ncaaf/teams.py
@@ -2,6 +2,7 @@ import pandas as pd
 import re
 from .constants import PARSING_SCHEME, OFFENSIVE_STATS_URL, SEASON_PAGE_URL
 from pyquery import PyQuery as pq
+from ..decorators import float_property_decorator, int_property_decorator
 from .. import utils
 from .schedule import Schedule
 
@@ -158,88 +159,79 @@ class Team(object):
         """
         return self._name
 
-    @property
+    @int_property_decorator
     def games(self):
         """
         Returns an ``int`` of the total number of games the team has played
         during the season.
         """
-        return int(self._games)
+        return self._games
 
-    @property
+    @int_property_decorator
     def wins(self):
         """
         Returns an ``int`` of the total number of games the team won during the
         season.
         """
-        return int(self._wins)
+        return self._wins
 
-    @property
+    @int_property_decorator
     def losses(self):
         """
         Returns an ``int`` of the total number of games the team lost during
         the season.
         """
-        return int(self._losses)
+        return self._losses
 
-    @property
+    @float_property_decorator
     def win_percentage(self):
         """
         Returns a ``float`` of the percentage of wins divided by the number of
         games played during the season. Percentage ranges from 0-1.
         """
-        return float(self._win_percentage)
+        return self._win_percentage
 
-    @property
+    @int_property_decorator
     def conference_wins(self):
         """
         Returns an ``int`` of the total number of conference games the team won
         during the season.
         """
-        try:
-            return int(self._conference_wins)
-        except ValueError:
-            return 0
+        return self._conference_wins
 
-    @property
+    @int_property_decorator
     def conference_losses(self):
         """
         Returns an ``int`` of the total number of conference games the team
         lost during the season.
         """
-        try:
-            return int(self._conference_losses)
-        except ValueError:
-            return 0
+        return self._conference_losses
 
-    @property
+    @float_property_decorator
     def conference_win_percentage(self):
         """
         Returns a ``float`` of the percentage of conference wins divided by the
         number of conference games played during the season. Percentage ranges
         from 0-1.
         """
-        try:
-            return float(self._conference_win_percentage)
-        except ValueError:
-            return 0
+        return self._conference_win_percentage
 
-    @property
+    @float_property_decorator
     def points_per_game(self):
         """
         Returns a ``float`` of the average number of points scored by the team
         per game.
         """
-        return float(self._points_per_game)
+        return self._points_per_game
 
-    @property
+    @float_property_decorator
     def points_against_per_game(self):
         """
         Returns a ``float`` of the average number of points conceded per game.
         """
-        return float(self._points_against_per_game)
+        return self._points_against_per_game
 
-    @property
+    @float_property_decorator
     def strength_of_schedule(self):
         """
         Returns a ``float`` of the team's strength of schedule based on the
@@ -247,9 +239,9 @@ class Team(object):
         is denoted with 0.0 while a negative score indicates a comparatively
         easy schedule.
         """
-        return float(self._strength_of_schedule)
+        return self._strength_of_schedule
 
-    @property
+    @float_property_decorator
     def simple_rating_system(self):
         """
         Returns a ``float`` of the team's relative strength based on the
@@ -257,167 +249,167 @@ class Team(object):
         is denoted with 0.0 while a negative score indicates a comparatively
         weak team.
         """
-        return float(self._simple_rating_system)
+        return self._simple_rating_system
 
-    @property
+    @float_property_decorator
     def pass_completions(self):
         """
         Returns a ``float`` of the average number of completed passes per game.
         """
-        return float(self._pass_completions)
+        return self._pass_completions
 
-    @property
+    @float_property_decorator
     def pass_attempts(self):
         """
         Returns a ``float`` of the average number of passes that are attempted
         per game.
         """
-        return float(self._pass_attempts)
+        return self._pass_attempts
 
-    @property
+    @float_property_decorator
     def pass_completion_percentage(self):
         """
         Returns a ``float`` of the percentage of completed passes per game.
         Percentage ranges from 0-100.
         """
-        return float(self._pass_completion_percentage)
+        return self._pass_completion_percentage
 
-    @property
+    @float_property_decorator
     def pass_yards(self):
         """
         Returns a ``float`` of the average number of yards gained from passing
         per game.
         """
-        return float(self._pass_yards)
+        return self._pass_yards
 
-    @property
+    @float_property_decorator
     def interceptions(self):
         """
         Returns a ``float`` of the average number of interceptions thrown per
         game.
         """
-        return float(self._interceptions)
+        return self._interceptions
 
-    @property
+    @float_property_decorator
     def pass_touchdowns(self):
         """
         Returns a ``float`` of the average number of passing touchdowns scored
         per game.
         """
-        return float(self._pass_touchdowns)
+        return self._pass_touchdowns
 
-    @property
+    @float_property_decorator
     def rush_attempts(self):
         """
         Returns a ``float`` of the average number of rushing plays per game.
         """
-        return float(self._rush_attempts)
+        return self._rush_attempts
 
-    @property
+    @float_property_decorator
     def rush_yards(self):
         """
         Returns a ``float`` of the average number of yards gained from rushing
         per game.
         """
-        return float(self._rush_yards)
+        return self._rush_yards
 
-    @property
+    @float_property_decorator
     def rush_yards_per_attempt(self):
         """
         Returns a ``float`` of the average number of yards gained per rushing
         attempt per game.
         """
-        return float(self._rush_yards_per_attempt)
+        return self._rush_yards_per_attempt
 
-    @property
+    @float_property_decorator
     def rush_touchdowns(self):
         """
         Returns a ``float`` of the average number of rushing touchdowns scored
         per game.
         """
-        return float(self._rush_touchdowns)
+        return self._rush_touchdowns
 
-    @property
+    @float_property_decorator
     def plays(self):
         """
         Returns a ``float`` of the average number of offensive plays per game.
         """
-        return float(self._plays)
+        return self._plays
 
-    @property
+    @float_property_decorator
     def yards(self):
         """
         Returns a ``float`` of the average number of yards gained per game.
         """
-        return float(self._yards)
+        return self._yards
 
-    @property
+    @float_property_decorator
     def turnovers(self):
         """
         Returns a ``float`` of the average number of turnovers per game.
         """
-        return float(self._turnovers)
+        return self._turnovers
 
-    @property
+    @float_property_decorator
     def fumbles_lost(self):
         """
         Returns a ``float`` of the average number of fumbles per game.
         """
-        return float(self._fumbles_lost)
+        return self._fumbles_lost
 
-    @property
+    @float_property_decorator
     def yards_per_play(self):
         """
         Returns a ``float`` of the average number of yards gained per play.
         """
-        return float(self._yards_per_play)
+        return self._yards_per_play
 
-    @property
+    @float_property_decorator
     def pass_first_downs(self):
         """
         Returns a ``float`` of the average number of first downs from passing
         plays per game.
         """
-        return float(self._pass_first_downs)
+        return self._pass_first_downs
 
-    @property
+    @float_property_decorator
     def rush_first_downs(self):
         """
         Returns a ``float`` of the average number of first downs from rushing
         plays per game.
         """
-        return float(self._rush_first_downs)
+        return self._rush_first_downs
 
-    @property
+    @float_property_decorator
     def first_downs_from_penalties(self):
         """
         Returns a ``float`` of the average number of first downs from an
         opponent's penalties per game.
         """
-        return float(self._first_downs_from_penalties)
+        return self._first_downs_from_penalties
 
-    @property
+    @float_property_decorator
     def first_downs(self):
         """
         Returns a ``float`` of the total number of first downs achieved per
         game.
         """
-        return float(self._first_downs)
+        return self._first_downs
 
-    @property
+    @float_property_decorator
     def penalties(self):
         """
-        Returns the average number of penalties conceded per game.
+        Returns a ``float`` the average number of penalties conceded per game.
         """
-        return float(self._penalties)
+        return self._penalties
 
-    @property
+    @float_property_decorator
     def yards_from_penalties(self):
         """
         Returns a ``float`` of the average number of yards gained from an
         opponent's penalties per game.
         """
-        return float(self._yards_from_penalties)
+        return self._yards_from_penalties
 
 
 class Teams:

--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -2,12 +2,34 @@ import pandas as pd
 import re
 from pyquery import PyQuery as pq
 from .. import utils
+from ..decorators import int_property_decorator
 from .constants import (BOXSCORE_ELEMENT_INDEX,
+                        BOXSCORE_ELEMENT_SUB_INDEX,
                         BOXSCORE_SCHEME,
                         BOXSCORE_URL,
                         BOXSCORES_URL)
 from sportsreference import utils
 from sportsreference.constants import AWAY, HOME
+
+
+def nfl_int_property_sub_index(func):
+    # Decorator dedicated to properties with sub-indices, such as pass yards
+    # which is indexed within a table cell but also has multiple other values
+    # in that same cell that need to be ignored.
+    @property
+    def wrapper(*args):
+        value = func(*args)
+        # Equivalent to the calling property's method name
+        field = func.__name__
+        try:
+            field_items = value.replace('--', '-').split('-')
+        except AttributeError:
+            return None
+        try:
+            return int(field_items[BOXSCORE_ELEMENT_SUB_INDEX[field]])
+        except (TypeError, ValueError, IndexError):
+            return None
+    return wrapper
 
 
 class Boxscore(object):
@@ -321,13 +343,12 @@ class Boxscore(object):
         """
         return self._stadium.replace('Stadium: ', '')
 
-    @property
+    @int_property_decorator
     def attendance(self):
         """
         Returns an ``int`` of the game's listed attendance.
         """
-        attendance = self._attendance.replace('Attendance: ', '')
-        return int(attendance.replace(',', ''))
+        return self._attendance.replace('Attendance: ', '').replace(',', '')
 
     @property
     def duration(self):
@@ -386,215 +407,179 @@ class Boxscore(object):
             return utils._parse_abbreviation(self._away_name)
         return utils._parse_abbreviation(self._home_name)
 
-    @property
+    @int_property_decorator
     def away_points(self):
         """
         Returns an ``int`` of the number of points the away team scored.
         """
-        return int(self._away_points)
+        return self._away_points
 
-    @property
+    @int_property_decorator
     def away_first_downs(self):
         """
         Returns an ``int`` of the number of first downs the away team gained.
         """
-        return int(self._away_first_downs)
+        return self._away_first_downs
 
-    @property
+    @nfl_int_property_sub_index
     def away_rush_attempts(self):
         """
         Returns an ``int`` of the number of rushing plays the away team made.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._away_rush_attempts.split('-')
-        return int(rush_info[0])
+        return self._away_rush_attempts
 
-    @property
+    @nfl_int_property_sub_index
     def away_rush_yards(self):
         """
         Returns an ``int`` of the number of rushing yards the away team gained.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._away_rush_yards.split('-')
-        return int(rush_info[1])
+        return self._away_rush_yards
 
-    @property
+    @nfl_int_property_sub_index
     def away_rush_touchdowns(self):
         """
         Returns an ``int`` of the number of rushing touchdowns the away team
         scored.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._away_rush_touchdowns.split('-')
-        return int(rush_info[2])
+        return self._away_rush_touchdowns
 
-    @property
+    @nfl_int_property_sub_index
     def away_pass_completions(self):
         """
         Returns an ``int`` of the number of completed passes the away team
         made.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_pass_completions.split('-')
-        return int(pass_info[0])
+        return self._away_pass_completions
 
-    @property
+    @nfl_int_property_sub_index
     def away_pass_attempts(self):
         """
         Returns an ``int`` of the number of passes that were thrown by the away
         team.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_pass_attempts.split('-')
-        return int(pass_info[1])
+        return self._away_pass_attempts
 
-    @property
+    @nfl_int_property_sub_index
     def away_pass_yards(self):
         """
         Returns an ``int`` of the number of passing yards the away team gained.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_pass_yards.split('-')
-        return int(pass_info[2])
+        return self._away_pass_yards
 
-    @property
+    @nfl_int_property_sub_index
     def away_pass_touchdowns(self):
         """
         Returns an ``int`` of the number of passing touchdowns the away team
         scored.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_pass_touchdowns.split('-')
-        return int(pass_info[3])
+        return self._away_pass_touchdowns
 
-    @property
+    @nfl_int_property_sub_index
     def away_interceptions(self):
         """
         Returns an ``int`` of the number of interceptions the away team threw.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._away_interceptions.split('-')
-        return int(pass_info[4])
+        return self._away_interceptions
 
-    @property
+    @nfl_int_property_sub_index
     def away_times_sacked(self):
         """
         Returns an ``int`` of the number of times the away team was sacked.
         """
-        # Sacks info is in the format 'Sacked-Yards'
-        sacks_info = self._away_times_sacked.split('-')
-        return int(sacks_info[0])
+        return self._away_times_sacked
 
-    @property
+    @nfl_int_property_sub_index
     def away_yards_lost_from_sacks(self):
         """
         Returns an ``int`` of the number of yards the away team lost as the
         result of a sack.
         """
-        # Sacks info is in the format 'Sacked-Yards'
-        sacks_info = self._away_yards_lost_from_sacks.split('-')
-        return int(sacks_info[1])
+        return self._away_yards_lost_from_sacks
 
-    @property
+    @int_property_decorator
     def away_net_pass_yards(self):
         """
         Returns an ``int`` of the net pass yards gained by the away team.
         """
-        return int(self._away_net_pass_yards)
+        return self._away_net_pass_yards
 
-    @property
+    @int_property_decorator
     def away_total_yards(self):
         """
         Returns an ``int`` of the total number of yards the away team gained.
         """
-        return int(self._away_total_yards)
+        return self._away_total_yards
 
-    @property
+    @nfl_int_property_sub_index
     def away_fumbles(self):
         """
         Returns an ``int`` of the number of times the away team fumbled the
         ball.
         """
-        # Fumble info is in the format 'Fumbles-Lost'
-        fumble_info = self._away_fumbles.split('-')
-        return int(fumble_info[0])
+        return self._away_fumbles
 
-    @property
+    @nfl_int_property_sub_index
     def away_fumbles_lost(self):
         """
         Returns an ``int`` of the number of times the away team turned the ball
         over as the result of a fumble.
         """
-        # Fumble info is in the format 'Fumbles-Lost'
-        fumble_info = self._away_fumbles.split('-')
-        return int(fumble_info[1])
+        return self._away_fumbles
 
-    @property
+    @int_property_decorator
     def away_turnovers(self):
         """
         Returns an ``int`` of the number of times the away team turned the ball
         over.
         """
-        return int(self._away_turnovers)
+        return self._away_turnovers
 
-    @property
+    @nfl_int_property_sub_index
     def away_penalties(self):
         """
         Returns an ``int`` of the number of penalties called on the away team.
         """
-        # Penalties info is in the format 'Penalties-Yards'
-        penalties_info = self._away_penalties.split('-')
-        return int(penalties_info[0])
+        return self._away_penalties
 
-    @property
+    @nfl_int_property_sub_index
     def away_yards_from_penalties(self):
         """
         Returns an ``int`` of the number of yards gifted as a result of
         penalties called on the away team.
         """
-        # Penalties info is in the format 'Penalties-Yards'
-        penalties_info = self._away_yards_from_penalties.split('-')
-        return int(penalties_info[1])
+        return self._away_yards_from_penalties
 
-    @property
+    @nfl_int_property_sub_index
     def away_third_down_conversions(self):
         """
         Returns an ``int`` of the number of third down plays the away team
         successfully converted.
         """
-        # Conversion info is in the format 'Conversions-Attempts'
-        conversion_info = self._away_third_down_conversions.split('-')
-        return int(conversion_info[0])
+        return self._away_third_down_conversions
 
-    @property
+    @nfl_int_property_sub_index
     def away_third_down_attempts(self):
         """
         Returns an ``int`` of the number of third down plays the away team
         attempted to convert.
         """
-        # Conversion info is in the format 'Conversions-Attempts'
-        conversion_info = self._away_third_down_attempts.split('-')
-        return int(conversion_info[1])
+        return self._away_third_down_attempts
 
-    @property
+    @nfl_int_property_sub_index
     def away_fourth_down_conversions(self):
         """
         Returns an ``int`` of the number of fourth down plays the away team
         successfully converted.
         """
-        # Conversion info is in the format 'Conversions-Attempts'
-        conversion_info = self._away_fourth_down_conversions.split('-')
-        return int(conversion_info[0])
+        return self._away_fourth_down_conversions
 
-    @property
+    @nfl_int_property_sub_index
     def away_fourth_down_attempts(self):
         """
         Returns an ``int`` of the number of fourth down plays the away team
         attempted to convert.
         """
-        # Conversion info is in the format 'Conversions-Attempts'
-        conversion_info = self._away_fourth_down_attempts.split('-')
-        return int(conversion_info[1])
+        return self._away_fourth_down_attempts
 
     @property
     def away_time_of_possession(self):
@@ -604,215 +589,179 @@ class Boxscore(object):
         """
         return self._away_time_of_possession
 
-    @property
+    @int_property_decorator
     def home_points(self):
         """
         Returns an ``int`` of the number of points the home team scored.
         """
-        return int(self._home_points)
+        return self._home_points
 
-    @property
+    @int_property_decorator
     def home_first_downs(self):
         """
         Returns an ``int`` of the number of first downs the home team gained.
         """
-        return int(self._home_first_downs)
+        return self._home_first_downs
 
-    @property
+    @nfl_int_property_sub_index
     def home_rush_attempts(self):
         """
         Returns an ``int`` of the number of rushing plays the home team made.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._home_rush_attempts.split('-')
-        return int(rush_info[0])
+        return self._home_rush_attempts
 
-    @property
+    @nfl_int_property_sub_index
     def home_rush_yards(self):
         """
         Returns an ``int`` of the number of rushing yards the home team gained.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._home_rush_yards.split('-')
-        return int(rush_info[1])
+        return self._home_rush_yards
 
-    @property
+    @nfl_int_property_sub_index
     def home_rush_touchdowns(self):
         """
         Returns an ``int`` of the number of rushing touchdowns the home team
         scored.
         """
-        # Rush info is in the format 'Rush-Yds-TDs'
-        rush_info = self._home_rush_touchdowns.split('-')
-        return int(rush_info[2])
+        return self._home_rush_touchdowns
 
-    @property
+    @nfl_int_property_sub_index
     def home_pass_completions(self):
         """
         Returns an ``int`` of the number of completed passes the home team
         made.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_completions.split('-')
-        return int(pass_info[0])
+        return self._home_pass_completions
 
-    @property
+    @nfl_int_property_sub_index
     def home_pass_attempts(self):
         """
         Returns an ``int`` of the number of passes that were thrown by the home
         team.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_attempts.split('-')
-        return int(pass_info[1])
+        return self._home_pass_attempts
 
-    @property
+    @nfl_int_property_sub_index
     def home_pass_yards(self):
         """
         Returns an ``int`` of the number of passing yards the home team gained.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_yards.split('-')
-        return int(pass_info[2])
+        return self._home_pass_yards
 
-    @property
+    @nfl_int_property_sub_index
     def home_pass_touchdowns(self):
         """
         Returns an ``int`` of the number of passing touchdowns the home team
         scored.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_touchdowns.split('-')
-        return int(pass_info[3])
+        return self._home_pass_touchdowns
 
-    @property
+    @nfl_int_property_sub_index
     def home_interceptions(self):
         """
         Returns an ``int`` of the number of interceptions the home team threw.
         """
-        # Pass info is in the format 'Cmp-Att-Yd-TD-INT'
-        pass_info = self._home_pass_touchdowns.split('-')
-        return int(pass_info[4])
+        return self._home_pass_touchdowns
 
-    @property
+    @nfl_int_property_sub_index
     def home_times_sacked(self):
         """
         Returns an ``int`` of the number of times the home team was sacked.
         """
-        # Sacks info is in the format 'Sacked-Yards'
-        sacks_info = self._home_times_sacked.split('-')
-        return int(sacks_info[0])
+        return self._home_times_sacked
 
-    @property
+    @nfl_int_property_sub_index
     def home_yards_lost_from_sacks(self):
         """
         Returns an ``int`` of the number of yards the home team lost as the
         result of a sack.
         """
-        # Sacks info is in the format 'Sacked-Yards'
-        fumble_info = self._home_yards_lost_from_sacks.split('-')
-        return int(fumble_info[1])
+        return self._home_yards_lost_from_sacks
 
-    @property
+    @int_property_decorator
     def home_net_pass_yards(self):
         """
         Returns an ``int`` of the net pass yards gained by the home team.
         """
-        return int(self._home_net_pass_yards)
+        return self._home_net_pass_yards
 
-    @property
+    @int_property_decorator
     def home_total_yards(self):
         """
         Returns an ``int`` of the total number of yards the home team gained.
         """
-        return int(self._home_total_yards)
+        return self._home_total_yards
 
-    @property
+    @nfl_int_property_sub_index
     def home_fumbles(self):
         """
         Returns an ``int`` of the number of times the home team fumbled the
         ball.
         """
-        # Fumble info is in the format 'Fumbles-Lost'
-        fumble_info = self._home_fumbles.split('-')
-        return int(fumble_info[0])
+        return self._home_fumbles
 
-    @property
+    @nfl_int_property_sub_index
     def home_fumbles_lost(self):
         """
         Returns an ``int`` of the number of times the home team turned the ball
         over as the result of a fumble.
         """
-        # Fumble info is in the format 'Fumbles-Lost'
-        fumble_info = self._home_fumbles_lost.split('-')
-        return int(fumble_info[1])
+        return self._home_fumbles_lost
 
-    @property
+    @int_property_decorator
     def home_turnovers(self):
         """
         Returns an ``int`` of the number of times the home team turned the ball
         over.
         """
-        return int(self._home_turnovers)
+        return self._home_turnovers
 
-    @property
+    @nfl_int_property_sub_index
     def home_penalties(self):
         """
         Returns an ``int`` of the number of penalties called on the home team.
         """
-        # Penalties info is in the format 'Penalties-Yards'
-        penalties_info = self._home_penalties.split('-')
-        return int(penalties_info[0])
+        return self._home_penalties
 
-    @property
+    @nfl_int_property_sub_index
     def home_yards_from_penalties(self):
         """
         Returns an ``int`` of the number of yards gifted as a result of
         penalties called on the home team.
         """
-        # Penalties info is in the format 'Penalties-Yards'
-        penalties_info = self._home_yards_from_penalties.split('-')
-        return int(penalties_info[1])
+        return self._home_yards_from_penalties
 
-    @property
+    @nfl_int_property_sub_index
     def home_third_down_conversions(self):
         """
         Returns an ``int`` of the number of third down plays the home team
         successfully converted.
         """
-        # Conversion info is in the format 'Conversions-Attempts'
-        conversion_info = self._home_third_down_conversions.split('-')
-        return int(conversion_info[0])
+        return self._home_third_down_conversions
 
-    @property
+    @nfl_int_property_sub_index
     def home_third_down_attempts(self):
         """
         Returns an ``int`` of the number of third down plays the home team
         attempted to convert.
         """
-        # Conversion info is in the format 'Conversions-Attempts'
-        conversion_info = self._home_third_down_attempts.split('-')
-        return int(conversion_info[1])
+        return self._home_third_down_attempts
 
-    @property
+    @nfl_int_property_sub_index
     def home_fourth_down_conversions(self):
         """
         Returns an ``int`` of the number of fourth down plays the home team
         successfully converted.
         """
-        # Conversion info is in the format 'Conversions-Attempts'
-        conversion_info = self._home_fourth_down_conversions.split('-')
-        return int(conversion_info[0])
+        return self._home_fourth_down_conversions
 
-    @property
+    @nfl_int_property_sub_index
     def home_fourth_down_attempts(self):
         """
         Returns an ``int`` of the number of fourth down plays the home team
         attempted to convert.
         """
-        # Conversion info is in the format 'Conversions-Attempts'
-        conversion_info = self._home_fourth_down_conversions.split('-')
-        return int(conversion_info[1])
+        return self._home_fourth_down_conversions
 
     @property
     def home_time_of_possession(self):

--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -8,6 +8,7 @@ from .constants import (BOXSCORE_ELEMENT_INDEX,
                         BOXSCORE_SCHEME,
                         BOXSCORE_URL,
                         BOXSCORES_URL)
+from functools import wraps
 from sportsreference import utils
 from sportsreference.constants import AWAY, HOME
 
@@ -17,6 +18,7 @@ def nfl_int_property_sub_index(func):
     # which is indexed within a table cell but also has multiple other values
     # in that same cell that need to be ignored.
     @property
+    @wraps(func)
     def wrapper(*args):
         value = func(*args)
         # Equivalent to the calling property's method name

--- a/sportsreference/nfl/constants.py
+++ b/sportsreference/nfl/constants.py
@@ -189,6 +189,46 @@ BOXSCORE_ELEMENT_INDEX = {
     'home_time_of_possession': 11
 }
 
+# Designates the index of the item within the requested tag
+BOXSCORE_ELEMENT_SUB_INDEX = {
+    'away_rush_attempts': 0,
+    'away_rush_yards': 1,
+    'away_rush_touchdowns': 2,
+    'away_pass_completions': 0,
+    'away_pass_attempts': 1,
+    'away_pass_yards': 2,
+    'away_pass_touchdowns': 3,
+    'away_interceptions': 4,
+    'away_times_sacked': 0,
+    'away_yards_lost_from_sacks': 1,
+    'away_fumbles': 0,
+    'away_fumbles_lost': 1,
+    'away_penalties': 0,
+    'away_yards_from_penalties': 1,
+    'away_third_down_conversions': 0,
+    'away_third_down_attempts': 1,
+    'away_fourth_down_conversions': 0,
+    'away_fourth_down_attempts': 1,
+    'home_rush_attempts': 0,
+    'home_rush_yards': 1,
+    'home_rush_touchdowns': 2,
+    'home_pass_completions': 0,
+    'home_pass_attempts': 1,
+    'home_pass_yards': 2,
+    'home_pass_touchdowns': 3,
+    'home_interceptions': 4,
+    'home_times_sacked': 0,
+    'home_yards_lost_from_sacks': 1,
+    'home_fumbles': 0,
+    'home_fumbles_lost': 1,
+    'home_penalties': 0,
+    'home_yards_from_penalties': 1,
+    'home_third_down_conversions': 0,
+    'home_third_down_attempts': 1,
+    'home_fourth_down_conversions': 0,
+    'home_fourth_down_attempts': 1,
+}
+
 SEASON_PAGE_URL = 'http://www.pro-football-reference.com/years/%s.html'
 
 SCHEDULE_URL = 'https://www.pro-football-reference.com/teams/%s/%s/gamelog/'

--- a/sportsreference/nfl/schedule.py
+++ b/sportsreference/nfl/schedule.py
@@ -527,7 +527,7 @@ class Game(object):
         return self._time_of_possession
 
 
-class Schedule:
+class Schedule(object):
     """
     An object of the given team's schedule.
 
@@ -666,7 +666,11 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe)
+            df = game.dataframe
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)
 
     @property
@@ -680,5 +684,9 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe_extended)
+            df = game.dataframe_extended
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)

--- a/sportsreference/nfl/schedule.py
+++ b/sportsreference/nfl/schedule.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+from ..decorators import float_property_decorator, int_property_decorator
 from .constants import (SCHEDULE_SCHEME,
                         SCHEDULE_URL)
 from datetime import datetime
@@ -210,7 +211,7 @@ class Game(object):
         """
         return self.boxscore.dataframe
 
-    @property
+    @int_property_decorator
     def week(self):
         """
         Returns an ``int`` of the week number in the season, such as 1 for the
@@ -224,7 +225,7 @@ class Game(object):
             return CONF_CHAMPIONSHIP
         if self._week.lower() == 'superbowl':
             return SUPER_BOWL
-        return int(self._week)
+        return self._week
 
     @property
     def day(self):
@@ -281,7 +282,7 @@ class Game(object):
     @property
     def overtime(self):
         """
-        Returns a boolean value that evaluates to True if the game when to
+        Returns a ``boolean`` value that evaluates to True if the game when to
         overtime and False if it ended in regulation.
         """
         if self._overtime != '':
@@ -316,206 +317,206 @@ class Game(object):
         """
         return self._opponent_name
 
-    @property
+    @int_property_decorator
     def points_scored(self):
         """
         Returns an ``int`` of the number of points scored by the team.
         """
-        return int(self._points_scored)
+        return self._points_scored
 
-    @property
+    @int_property_decorator
     def points_allowed(self):
         """
         Returns an ``int`` of the number of points allowed by the team.
         """
-        return int(self._points_allowed)
+        return self._points_allowed
 
-    @property
+    @int_property_decorator
     def pass_completions(self):
         """
         Returns an ``int`` of the number of completed passed by the team.
         """
-        return int(self._pass_completions)
+        return self._pass_completions
 
-    @property
+    @int_property_decorator
     def pass_attempts(self):
         """
         Returns an ``int`` of the number of passes the team attempted during
         the game.
         """
-        return int(self._pass_attempts)
+        return self._pass_attempts
 
-    @property
+    @int_property_decorator
     def pass_yards(self):
         """
         Returns an ``int`` of the number of yards the team gained as a result
         of passing plays.
         """
-        return int(self._pass_yards)
+        return self._pass_yards
 
-    @property
+    @int_property_decorator
     def pass_touchdowns(self):
         """
         Returns an ``int`` of the number of touchdowns the team scored as a
         result of passing plays.
         """
-        return int(self._pass_touchdowns)
+        return self._pass_touchdowns
 
-    @property
+    @int_property_decorator
     def interceptions(self):
         """
         Returns an ``int`` of the number of interceptions the team threw.
         """
-        return int(self._interceptions)
+        return self._interceptions
 
-    @property
+    @int_property_decorator
     def times_sacked(self):
         """
         Returns an ``int`` of the number of times the quarterback was sacked by
         the opponent.
         """
-        return int(self._times_sacked)
+        return self._times_sacked
 
-    @property
+    @int_property_decorator
     def yards_lost_from_sacks(self):
         """
         Returns an ``int`` of the total number of yards lost as a result of a
         sack.
         """
-        return int(self._yards_lost_from_sacks)
+        return self._yards_lost_from_sacks
 
-    @property
+    @float_property_decorator
     def pass_yards_per_attempt(self):
         """
         Returns a ``float`` of the average number of yards gained per passing
         play.
         """
-        return float(self._pass_yards_per_attempt)
+        return self._pass_yards_per_attempt
 
-    @property
+    @float_property_decorator
     def pass_completion_rate(self):
         """
         Returns a ``float`` of the percentage of passes that were completed by
         the team. Percentage ranges from 0-100.
         """
-        return float(self._pass_completion_rate)
+        return self._pass_completion_rate
 
-    @property
+    @float_property_decorator
     def quarterback_rating(self):
         """
         Returns a ``float`` of the quarterback's rating for the game.
         """
-        return float(self._quarterback_rating)
+        return self._quarterback_rating
 
-    @property
+    @int_property_decorator
     def rush_attempts(self):
         """
         Returns an ``int`` of the total number of times the team attempted a
         rushing play.
         """
-        return int(self._rush_attempts)
+        return self._rush_attempts
 
-    @property
+    @int_property_decorator
     def rush_yards(self):
         """
         Returns an ``int`` of the total number of yards the team gain as a
         result of rushing plays.
         """
-        return int(self._rush_yards)
+        return self._rush_yards
 
-    @property
+    @float_property_decorator
     def rush_yards_per_attempt(self):
         """
         Returns a ``float`` of the average number of yards gained per rushing
         play.
         """
-        return float(self._rush_yards_per_attempt)
+        return self._rush_yards_per_attempt
 
-    @property
+    @int_property_decorator
     def rush_touchdowns(self):
         """
         Returns an ``int`` of the number of touchdowns the team scored as a
         result of rushing plays.
         """
-        return int(self._rush_touchdowns)
+        return self._rush_touchdowns
 
-    @property
+    @int_property_decorator
     def field_goals_made(self):
         """
         Returns an ``int`` of the total number of field goals the team scored.
         """
-        return int(self._field_goals_made)
+        return self._field_goals_made
 
-    @property
+    @int_property_decorator
     def field_goals_attempted(self):
         """
         Returns an ``int`` of the total number of times the team attempted a
         field goal.
         """
-        return int(self._field_goals_attempted)
+        return self._field_goals_attempted
 
-    @property
+    @int_property_decorator
     def extra_points_made(self):
         """
         Returns an ``int`` of the number of extra points the team successfully
         converted after scoring a touchdown.
         """
-        return int(self._extra_points_made)
+        return self._extra_points_made
 
-    @property
+    @int_property_decorator
     def extra_points_attempted(self):
         """
         Returns an ``int`` of the number of times the team attempted to convert
         an extra point after scoring a touchdown.
         """
-        return int(self._extra_points_attempted)
+        return self._extra_points_attempted
 
-    @property
+    @int_property_decorator
     def punts(self):
         """
         Returns an ``int`` of the number of times the team punted the ball.
         """
-        return int(self._punts)
+        return self._punts
 
-    @property
+    @int_property_decorator
     def punt_yards(self):
         """
         Returns an ``int`` of the total number of yards the team punted the
         ball.
         """
-        return int(self._punt_yards)
+        return self._punt_yards
 
-    @property
+    @int_property_decorator
     def third_down_conversions(self):
         """
         Returns an ``int`` of the number of third downs the team successfully
         converted.
         """
-        return int(self._third_down_conversions)
+        return self._third_down_conversions
 
-    @property
+    @int_property_decorator
     def third_down_attempts(self):
         """
         Returns an ``int`` of the total number of third downs the team
         attempted to convert.
         """
-        return int(self._third_down_attempts)
+        return self._third_down_attempts
 
-    @property
+    @int_property_decorator
     def fourth_down_conversions(self):
         """
         Returns an ``int`` of the number of fourth downs the team successfully
         converted.
         """
-        return int(self._fourth_down_conversions)
+        return self._fourth_down_conversions
 
-    @property
+    @int_property_decorator
     def fourth_down_attempts(self):
         """
         Returns an ``int`` of the total number of fourth downs the team
         attempted to convert.
         """
-        return int(self._fourth_down_attempts)
+        return self._fourth_down_attempts
 
     @property
     def time_of_possession(self):

--- a/sportsreference/nfl/teams.py
+++ b/sportsreference/nfl/teams.py
@@ -2,6 +2,7 @@ import pandas as pd
 import re
 from .constants import PARSING_SCHEME, SEASON_PAGE_URL
 from pyquery import PyQuery as pq
+from ..decorators import float_property_decorator, int_property_decorator
 from .. import utils
 from .schedule import Schedule
 
@@ -154,13 +155,13 @@ class Team:
         }
         return pd.DataFrame([fields_to_include], index=[self._abbreviation])
 
-    @property
+    @int_property_decorator
     def rank(self):
         """
         Returns an ``int`` of the team's rank based on the number of points
         they scored during the season.
         """
-        return int(self._rank)
+        return self._rank
 
     @property
     def abbreviation(self):
@@ -186,293 +187,293 @@ class Team:
         """
         return self._name
 
-    @property
+    @int_property_decorator
     def wins(self):
         """
         Returns an ``int`` of the number of games the team won during the
         season.
         """
-        return int(self._wins)
+        return self._wins
 
-    @property
+    @int_property_decorator
     def losses(self):
         """
         Returns an ``int`` of the number of games the team lost during the
         season.
         """
-        return int(self._losses)
+        return self._losses
 
-    @property
+    @float_property_decorator
     def win_percentage(self):
         """
         Returns a ``float`` of the number of wins divided by the number of
         games played. Percentage ranges from 0-1.
         """
-        return float(self._win_percentage)
+        return self._win_percentage
 
-    @property
+    @int_property_decorator
     def games_played(self):
         """
         Returns an ``int`` of the number of games played during the season.
         """
-        return int(self._games_played)
+        return self._games_played
 
-    @property
+    @int_property_decorator
     def points_for(self):
         """
         Returns an ``int`` of the total number of points scored during the
         season.
         """
-        return int(self._points_for)
+        return self._points_for
 
-    @property
+    @int_property_decorator
     def points_against(self):
         """
         Returns an ``int`` of the total number of points allowed during the
         season.
         """
-        return int(self._points_against)
+        return self._points_against
 
-    @property
+    @int_property_decorator
     def points_difference(self):
         """
         Returns an ``int`` of the difference between the number of points
         scored and allowed during the season.
         """
-        return int(self._points_difference)
+        return self._points_difference
 
-    @property
+    @float_property_decorator
     def margin_of_victory(self):
         """
         Returns a ``float`` of the average margin of victory per game.
         """
-        return float(self._margin_of_victory)
+        return self._margin_of_victory
 
-    @property
+    @float_property_decorator
     def strength_of_schedule(self):
         """
         Returns a ``float`` of the team's strength of schedule. An average
         difficulty schedule is denoted with a 0.0 and a negative number is
         comparatively easier than average.
         """
-        return float(self._strength_of_schedule)
+        return self._strength_of_schedule
 
-    @property
+    @float_property_decorator
     def simple_rating_system(self):
         """
         Returns a ``float`` of the team's relative strength based on average
         margin of victory plus strength of schedule. An average team is denoted
         with 0.0 and a negative score is a comparatively weaker team.
         """
-        return float(self._simple_rating_system)
+        return self._simple_rating_system
 
-    @property
+    @float_property_decorator
     def offensive_simple_rating_system(self):
         """
         Returns a ``float`` of the team's offensive strength according to the
         simple rating system. An average team is denoted with 0.0 and a
         negative score is a comparatively weaker team.
         """
-        return float(self._offensive_simple_rating_system)
+        return self._offensive_simple_rating_system
 
-    @property
+    @float_property_decorator
     def defensive_simple_rating_system(self):
         """
         Returns a ``float`` of the team's defensive strength according to the
         simple rating system. An average team is denoted with 0.0 and a
         negative score is a comparatively weaker team.
         """
-        return float(self._defensive_simple_rating_system)
+        return self._defensive_simple_rating_system
 
-    @property
+    @int_property_decorator
     def yards(self):
         """
         Returns an ``int`` of the total number of yards the team has gained
         during the season.
         """
-        return int(self._yards)
+        return self._yards
 
-    @property
+    @int_property_decorator
     def plays(self):
         """
         Returns an ``int`` of the total number of offensive plays the team has
         made during the season.
         """
-        return int(self._plays)
+        return self._plays
 
-    @property
+    @float_property_decorator
     def yards_per_play(self):
         """
         Returns a ``float`` of the average number of yards gained per play
         during the season.
         """
-        return float(self._yards_per_play)
+        return self._yards_per_play
 
-    @property
+    @int_property_decorator
     def turnovers(self):
         """
         Returns an ``int`` of the total number of turnovers the team committed
         during the season.
         """
-        return int(self._turnovers)
+        return self._turnovers
 
-    @property
+    @int_property_decorator
     def fumbles(self):
         """
         Returns an ``int`` of the total number of times the team fumbled the
         ball during the season.
         """
-        return int(self._fumbles)
+        return self._fumbles
 
-    @property
+    @int_property_decorator
     def first_downs(self):
         """
         Returns an ``int`` of the total number of first downs the team achieved
         during the season.
         """
-        return int(self._first_downs)
+        return self._first_downs
 
-    @property
+    @int_property_decorator
     def pass_completions(self):
         """
         Returns an ``int`` of the total number of passes that were completed.
         """
-        return int(self._pass_completions)
+        return self._pass_completions
 
-    @property
+    @int_property_decorator
     def pass_attempts(self):
         """
         Returns an ``int`` of the total number of passes that were attempted.
         """
-        return int(self._pass_attempts)
+        return self._pass_attempts
 
-    @property
+    @int_property_decorator
     def pass_yards(self):
         """
         Returns an ``int`` of the total number of yards the team gained from
         passing.
         """
-        return int(self._pass_yards)
+        return self._pass_yards
 
-    @property
+    @int_property_decorator
     def pass_touchdowns(self):
         """
         Returns an ``int`` of the total number of touchdowns the team has
         scored from passing.
         """
-        return int(self._pass_touchdowns)
+        return self._pass_touchdowns
 
-    @property
+    @int_property_decorator
     def interceptions(self):
         """
         Returns an ``int`` of the total number of interceptions the team has
         thrown.
         """
-        return int(self._interceptions)
+        return self._interceptions
 
-    @property
+    @float_property_decorator
     def pass_net_yards_per_attempt(self):
         """
         Returns a ``float`` of the net yards gained per passing play including
         sacks.
         """
-        return float(self._pass_net_yards_per_attempt)
+        return self._pass_net_yards_per_attempt
 
-    @property
+    @int_property_decorator
     def pass_first_downs(self):
         """
         Returns an ``int`` of the number of first downs the team gained from
         passing plays.
         """
-        return int(self._pass_first_downs)
+        return self._pass_first_downs
 
-    @property
+    @int_property_decorator
     def rush_attempts(self):
         """
         Returns an ``int`` of the total number of rushing plays that were
         attempted.
         """
-        return int(self._rush_attempts)
+        return self._rush_attempts
 
-    @property
+    @int_property_decorator
     def rush_yards(self):
         """
         Returns an ``int`` of the total number of yards that were gained from
         rushing plays.
         """
-        return int(self._rush_yards)
+        return self._rush_yards
 
-    @property
+    @int_property_decorator
     def rush_touchdowns(self):
         """
         Returns an ``int`` of the total number of touchdowns from rushing
         plays.
         """
-        return int(self._rush_touchdowns)
+        return self._rush_touchdowns
 
-    @property
+    @float_property_decorator
     def rush_yards_per_attempt(self):
         """
         Returns a ``float`` of the average number of yards gained per rushing
         play.
         """
-        return float(self._rush_yards_per_attempt)
+        return self._rush_yards_per_attempt
 
-    @property
+    @int_property_decorator
     def rush_first_downs(self):
         """
         Returns an ``int`` of the total number of first downs gained from
         rushing plays.
         """
-        return int(self._rush_first_downs)
+        return self._rush_first_downs
 
-    @property
+    @int_property_decorator
     def penalties(self):
         """
         Returns an ``int`` of the total number of penalties called on the team
         during the season.
         """
-        return int(self._penalties)
+        return self._penalties
 
-    @property
+    @int_property_decorator
     def yards_from_penalties(self):
         """
         Returns an ``int`` of the total number of yards surrendered as a result
         of penalties called on the team.
         """
-        return int(self._yards_from_penalties)
+        return self._yards_from_penalties
 
-    @property
+    @int_property_decorator
     def first_downs_from_penalties(self):
         """
         Returns an ``int`` of the total number of first downs conceded as a
         result of penalties called on the team.
         """
-        return int(self._first_downs_from_penalties)
+        return self._first_downs_from_penalties
 
-    @property
+    @float_property_decorator
     def percent_drives_with_points(self):
         """
         Returns a ``float`` of the percentage of drives that result in points
         for the offense. Percentage ranges from 0-100.
         """
-        return float(self._percent_drives_with_points)
+        return self._percent_drives_with_points
 
-    @property
+    @float_property_decorator
     def percent_drives_with_turnovers(self):
         """
         Returns a ``float`` of the percentage of drives that result in an
         offensive turnover. Percentage ranges from 0-100.
         """
-        return float(self._percent_drives_with_turnovers)
+        return self._percent_drives_with_turnovers
 
-    @property
+    @float_property_decorator
     def points_contributed_by_offense(self):
         """
         Returns a ``float`` of the number of expected points contributed by the
         offense.
         """
-        return float(self._points_contributed_by_offense)
+        return self._points_contributed_by_offense
 
 
 class Teams:

--- a/sportsreference/nhl/boxscore.py
+++ b/sportsreference/nhl/boxscore.py
@@ -170,7 +170,10 @@ class Boxscore(object):
             # information and should retain their original index.
             if field != 'date' and field != 'time':
                 index += 1
-        return game_info[index]
+        try:
+            return game_info[index]
+        except IndexError:
+            return ''
 
     def _parse_name(self, field, boxscore):
         """

--- a/sportsreference/nhl/boxscore.py
+++ b/sportsreference/nhl/boxscore.py
@@ -7,12 +7,14 @@ from .constants import (BOXSCORE_ELEMENT_INDEX,
                         BOXSCORE_SCHEME,
                         BOXSCORE_URL,
                         BOXSCORES_URL)
+from functools import wraps
 from sportsreference import utils
 from sportsreference.constants import AWAY, HOME
 
 
 def nhl_int_property_decorator(func):
     @property
+    @wraps(func)
     def wrapper(*args):
         value = func(*args)
         num_skaters = args[0]._away_skaters

--- a/sportsreference/nhl/schedule.py
+++ b/sportsreference/nhl/schedule.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import re
+from ..decorators import float_property_decorator, int_property_decorator
 from .constants import (SCHEDULE_SCHEME,
                         SCHEDULE_URL)
 from datetime import datetime
@@ -183,7 +184,7 @@ class Game(object):
         """
         return self.boxscore.dataframe
 
-    @property
+    @int_property_decorator
     def game(self):
         """
         Returns an ``int`` to indicate which game in the season was requested.
@@ -241,21 +242,21 @@ class Game(object):
         """
         return self._opponent_name
 
-    @property
+    @int_property_decorator
     def goals_scored(self):
         """
         Returns an ``int`` of the number of goals the team scored during the
         game.
         """
-        return int(self._goals_scored)
+        return self._goals_scored
 
-    @property
+    @int_property_decorator
     def goals_allowed(self):
         """
         Returns an ``int`` of the number of goals the team allowed during the
         game.
         """
-        return int(self._goals_allowed)
+        return self._goals_allowed
 
     @property
     def result(self):
@@ -270,7 +271,7 @@ class Game(object):
             return OVERTIME_LOSS
         return LOSS
 
-    @property
+    @int_property_decorator
     def overtime(self):
         """
         Returns an ``int`` of the number of overtimes that were played during
@@ -284,140 +285,104 @@ class Game(object):
             return 0
         num = re.findall('\d+', self._overtime)
         if len(num) > 0:
-            return int(num[0])
+            return num[0]
         return 0
 
-    @property
+    @int_property_decorator
     def shots_on_goal(self):
         """
         Returns an ``int`` of the total number of shots on goal the team
         registered.
         """
-        try:
-            return int(self._shots_on_goal)
-        except ValueError:
-            return 0
+        return self._shots_on_goal
 
-    @property
+    @int_property_decorator
     def penalties_in_minutes(self):
         """
         Returns an ``int`` of the total number of minutes the team served for
         penalties.
         """
-        try:
-            return int(self._penalties_in_minutes)
-        except ValueError:
-            return 0
+        return self._penalties_in_minutes
 
-    @property
+    @int_property_decorator
     def power_play_goals(self):
         """
         Returns an ``int`` of the number of power play goals the team scored.
         """
-        try:
-            return int(self._power_play_goals)
-        except ValueError:
-            return 0
+        return self._power_play_goals
 
-    @property
+    @int_property_decorator
     def power_play_opportunities(self):
         """
         Returns an ``int`` of the number of power play opportunities the team
         had.
         """
-        try:
-            return int(self._power_play_opportunities)
-        except ValueError:
-            return 0
+        return self._power_play_opportunities
 
-    @property
+    @int_property_decorator
     def short_handed_goals(self):
         """
         Returns an ``int`` of the number of shorthanded goals the team scored.
         """
-        try:
-            return int(self._short_handed_goals)
-        except ValueError:
-            return 0
+        return self._short_handed_goals
 
-    @property
+    @int_property_decorator
     def opp_shots_on_goal(self):
         """
         Returns an ``int`` of the total number of shots on goal the opponent
         registered.
         """
-        try:
-            return int(self._opp_shots_on_goal)
-        except ValueError:
-            return 0
+        return self._opp_shots_on_goal
 
-    @property
+    @int_property_decorator
     def opp_penalties_in_minutes(self):
         """
         Returns an ``int`` of the total number of minutes the opponent served
         for penalties.
         """
-        try:
-            return int(self._opp_penalties_in_minutes)
-        except ValueError:
-            return 0
+        return self._opp_penalties_in_minutes
 
-    @property
+    @int_property_decorator
     def opp_power_play_goals(self):
         """
         Returns an ``int`` of the number of power play goals the opponent
         scored.
         """
-        try:
-            return int(self._opp_power_play_goals)
-        except ValueError:
-            return 0
+        return self._opp_power_play_goals
 
-    @property
+    @int_property_decorator
     def opp_power_play_opportunities(self):
         """
         Returns an ``int`` of the number of power play opportunities the
         opponent had.
         """
-        try:
-            return int(self._opp_power_play_opportunities)
-        except ValueError:
-            return 0
+        return self._opp_power_play_opportunities
 
-    @property
+    @int_property_decorator
     def opp_short_handed_goals(self):
         """
         Returns an ``int`` of the number of shorthanded goals the opponent
         scored.
         """
-        try:
-            return int(self._opp_short_handed_goals)
-        except ValueError:
-            return 0
+        return self._opp_short_handed_goals
 
-    @property
+    @int_property_decorator
     def corsi_for(self):
         """
         Returns an ``int`` of the Corsi For at Even Strength metric which
         equals the number of shots + blocks + misses.
         """
-        try:
-            return int(self._corsi_for)
-        except ValueError:
-            return 0
+        return self._corsi_for
 
-    @property
+    @int_property_decorator
     def corsi_against(self):
         """
         Returns an ``int`` of the Corsi Against at Even Strength metric which
         equals the number of shots + blocks + misses by the opponent.
         """
-        try:
-            return int(self._corsi_against)
-        except ValueError:
-            return 0
+        return self._corsi_against
 
-    @property
+    @float_property_decorator
     def corsi_for_percentage(self):
         """
         Returns a ``float`` of the percentage of control a team had of the puck
@@ -426,34 +391,25 @@ class Game(object):
         had more control of the puck than their opponent. Percentage ranges
         from 0-100.
         """
-        try:
-            return float(self._corsi_for_percentage)
-        except ValueError:
-            return 0.0
+        return self._corsi_for_percentage
 
-    @property
+    @int_property_decorator
     def fenwick_for(self):
         """
         Returns an ``int`` of the Fenwick For at Even Strength metric which
         equals the number of shots + misses.
         """
-        try:
-            return int(self._fenwick_for)
-        except ValueError:
-            return 0
+        return self._fenwick_for
 
-    @property
+    @int_property_decorator
     def fenwick_against(self):
         """
         Returns an ``int`` of the Fenwick Against at Even Strength metric which
         equals the number of shots + misses by the opponent.
         """
-        try:
-            return int(self._fenwick_against)
-        except ValueError:
-            return 0
+        return self._fenwick_against
 
-    @property
+    @float_property_decorator
     def fenwick_for_percentage(self):
         """
         Returns a ``float`` of the percentage of control a team had of the puck
@@ -462,45 +418,33 @@ class Game(object):
         team had more control of the puck than their opponent. Percentage
         ranges from 0-100.
         """
-        try:
-            return float(self._fenwick_for_percentage)
-        except ValueError:
-            return 0.0
+        return self._fenwick_for_percentage
 
-    @property
+    @int_property_decorator
     def faceoff_wins(self):
         """
         Returns an ``int`` of the number of faceoffs the team won at even
         strength.
         """
-        try:
-            return int(self._faceoff_wins)
-        except ValueError:
-            return 0
+        return self._faceoff_wins
 
-    @property
+    @int_property_decorator
     def faceoff_losses(self):
         """
         Returns an ``int`` of the number of faceoffs the team lost at even
         strength.
         """
-        try:
-            return int(self._faceoff_losses)
-        except ValueError:
-            return 0
+        return self._faceoff_losses
 
-    @property
+    @float_property_decorator
     def faceoff_win_percentage(self):
         """
         Returns a ``float`` of percentage of faceoffs the team won while at
         even strength. Percentage ranges from 0-100.
         """
-        try:
-            return float(self._faceoff_win_percentage)
-        except ValueError:
-            return 0.0
+        return self._faceoff_win_percentage
 
-    @property
+    @float_property_decorator
     def offensive_zone_start_percentage(self):
         """
         Returns a ``float`` of the percentage of stats that took place in the
@@ -508,22 +452,16 @@ class Game(object):
         starts divided by the sum of offensive zone starts and defensive zone
         starts. Percentage ranges from 0-100.
         """
-        try:
-            return float(self._offensive_zone_start_percentage)
-        except ValueError:
-            return 0.0
+        return self._offensive_zone_start_percentage
 
-    @property
+    @float_property_decorator
     def pdo(self):
         """
         Returns a ``float`` of the team's PDO at Even Strength metric which is
         calculated by the sum of the shooting percentage and save percentage.
         Percentage ranges from 0-100.
         """
-        try:
-            return float(self._pdo)
-        except ValueError:
-            return 0.0
+        return self._pdo
 
 
 class Schedule:

--- a/sportsreference/nhl/schedule.py
+++ b/sportsreference/nhl/schedule.py
@@ -464,7 +464,7 @@ class Game(object):
         return self._pdo
 
 
-class Schedule:
+class Schedule(object):
     """
     An object of the given team's schedule.
 
@@ -583,7 +583,11 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe)
+            df = game.dataframe
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)
 
     @property
@@ -597,5 +601,9 @@ class Schedule:
         """
         frames = []
         for game in self.__iter__():
-            frames.append(game.dataframe_extended)
+            df = game.dataframe_extended
+            if df is not None:
+                frames.append(df)
+        if frames == []:
+            return None
         return pd.concat(frames)

--- a/sportsreference/nhl/teams.py
+++ b/sportsreference/nhl/teams.py
@@ -2,6 +2,7 @@ import pandas as pd
 import re
 from .constants import PARSING_SCHEME, SEASON_PAGE_URL
 from pyquery import PyQuery as pq
+from ..decorators import float_property_decorator, int_property_decorator
 from .. import utils
 from .schedule import Schedule
 
@@ -129,13 +130,13 @@ class Team:
         }
         return pd.DataFrame([fields_to_include], index=[self._abbreviation])
 
-    @property
+    @int_property_decorator
     def rank(self):
         """
         Returns an ``int`` of the team's rank based on the number of points
         they obtained in the season.
         """
-        return int(self._rank)
+        return self._rank
 
     @property
     def abbreviation(self):
@@ -161,80 +162,80 @@ class Team:
         """
         return self._name
 
-    @property
+    @float_property_decorator
     def average_age(self):
         """
         Returns a ``float`` of the average age of all players on the team,
         weighted by their time on ice.
         """
-        return float(self._average_age)
+        return self._average_age
 
-    @property
+    @int_property_decorator
     def games_played(self):
         """
         Returns an ``int`` of the total number of games the team has played in
         the season.
         """
-        return int(self._games_played)
+        return self._games_played
 
-    @property
+    @int_property_decorator
     def wins(self):
         """
         Returns an ``int`` of the total number of wins the team had in the
         season.
         """
-        return int(self._wins)
+        return self._wins
 
-    @property
+    @int_property_decorator
     def losses(self):
         """
         Returns an ``int`` of the total number of losses the team had in the
         season.
         """
-        return int(self._losses)
+        return self._losses
 
-    @property
+    @int_property_decorator
     def overtime_losses(self):
         """
         Returns an ``int`` of the total number of overtime losses the team had
         in the season.
         """
-        return int(self._overtime_losses)
+        return self._overtime_losses
 
-    @property
+    @int_property_decorator
     def points(self):
         """
         Returns an ``int`` of the total number of points the team gained in the
         season.
         """
-        return int(self._points)
+        return self._points
 
-    @property
+    @float_property_decorator
     def points_percentage(self):
         """
         Returns a ``float`` denoting the percentage of points gained divided by
         the maximum possible points available during the season. Percentage
         ranges from 0-1.
         """
-        return float(self._points_percentage)
+        return self._points_percentage
 
-    @property
+    @int_property_decorator
     def goals_for(self):
         """
         Returns an ``int`` of the total number of goals a team scored during
         the season.
         """
-        return int(self._goals_for)
+        return self._goals_for
 
-    @property
+    @int_property_decorator
     def goals_against(self):
         """
         Returns an ``int`` of the total number of goals opponents scored
         against the team during the season.
         """
-        return int(self._goals_against)
+        return self._goals_against
 
-    @property
+    @float_property_decorator
     def simple_rating_system(self):
         """
         Returns a ``float`` which takes into account the average goal
@@ -242,126 +243,126 @@ class Team:
         evaluates to 0.0. Teams which have a positive score are comparatively
         stronger than average while teams with a negative score are weaker.
         """
-        return float(self._simple_rating_system)
+        return self._simple_rating_system
 
-    @property
+    @float_property_decorator
     def strength_of_schedule(self):
         """
         Returns a ``float`` denoting a team's strength of schedule, based on
         goals scores and conceded. Higher values result in more challenging
         schedules while 0.0 is an average schedule.
         """
-        return float(self._strength_of_schedule)
+        return self._strength_of_schedule
 
-    @property
+    @float_property_decorator
     def total_goals_per_game(self):
         """
         Returns a ``float`` for the average number of goals scored per game.
         """
-        return float(self._total_goals_per_game)
+        return self._total_goals_per_game
 
-    @property
+    @int_property_decorator
     def power_play_goals(self):
         """
         Returns an ``int`` of the total number of power play goals scored.
         """
-        return int(self._power_play_goals)
+        return self._power_play_goals
 
-    @property
+    @int_property_decorator
     def power_play_opportunities(self):
         """
         Returns an ``int`` of the total number of power play opportunities for
         a team during the season.
         """
-        return int(self._power_play_opportunities)
+        return self._power_play_opportunities
 
-    @property
+    @float_property_decorator
     def power_play_percentage(self):
         """
         Returns a ``float`` denoting the percentage of power play opportunities
         where the team has scored. Percentage ranges from 0-100.
         """
-        return float(self._power_play_percentage)
+        return self._power_play_percentage
 
-    @property
+    @int_property_decorator
     def power_play_goals_against(self):
         """
         Returns an ``int`` of the total number of power play goals conceded.
         """
-        return int(self._power_play_goals_against)
+        return self._power_play_goals_against
 
-    @property
+    @int_property_decorator
     def power_play_opportunities_against(self):
         """
         Returns an ``int`` of the total number of power play opportunities for
         the opponents during the season.
         """
-        return int(self._power_play_opportunities_against)
+        return self._power_play_opportunities_against
 
-    @property
+    @float_property_decorator
     def penalty_killing_percentage(self):
         """
         Returns a ``float`` denoting the percentage of power plays that have
         been successfully defended without a goal being conceded. Percentage
         ranges from 0-100.
         """
-        return float(self._penalty_killing_percentage)
+        return self._penalty_killing_percentage
 
-    @property
+    @int_property_decorator
     def short_handed_goals(self):
         """
         Returns an ``int`` of the number of short handed goals the team has
         scored during the season.
         """
-        return int(self._short_handed_goals)
+        return self._short_handed_goals
 
-    @property
+    @int_property_decorator
     def short_handed_goals_against(self):
         """
         Returns an ``int`` of the number of short handed goals the team has
         conceded during the season.
         """
-        return int(self._short_handed_goals_against)
+        return self._short_handed_goals_against
 
-    @property
+    @int_property_decorator
     def shots_on_goal(self):
         """
         Returns an ``int`` of the total number of shots on goal the team made
         during the season.
         """
-        return int(self._shots_on_goal)
+        return self._shots_on_goal
 
-    @property
+    @float_property_decorator
     def shooting_percentage(self):
         """
         Returns a ``float`` denoting the percentage of shots to goals during
         the season. Percentage ranges from 0-100.
         """
-        return float(self._shooting_percentage)
+        return self._shooting_percentage
 
-    @property
+    @int_property_decorator
     def shots_against(self):
         """
         Returns an ``int`` of the total number of shots on goal the team's
         opponents made during the season.
         """
-        return int(self._shots_against)
+        return self._shots_against
 
-    @property
+    @float_property_decorator
     def save_percentage(self):
         """
         Returns a ``float`` denoting the percentage of shots the team has saved
         during the season. Percentage ranges from 0-1.
         """
-        return float(self._save_percentage)
+        return self._save_percentage
 
-    @property
+    @float_property_decorator
     def pdo_at_even_strength(self):
         """
         Returns a ``float`` of the PDO at even strength which equates to the
         shooting percentage plus the save percentage.
         """
-        return float(self._pdo_at_even_strength)
+        return self._pdo_at_even_strength
 
 
 class Teams:

--- a/sportsreference/utils.py
+++ b/sportsreference/utils.py
@@ -162,7 +162,10 @@ def _parse_field(parsing_scheme, html_data, field, index=0):
         return None
     # Default to returning the first element. Optionally return another element
     # if multiple fields have the same tag attribute.
-    return items[index]
+    try:
+        return items[index]
+    except IndexError:
+        return None
 
 
 def _remove_html_comment_tags(html):

--- a/tests/unit/test_mlb_boxscore.py
+++ b/tests/unit/test_mlb_boxscore.py
@@ -186,7 +186,7 @@ class TestMLBBoxscore:
         fake_attendance = PropertyMock(return_value='')
         type(self.boxscore)._attendance = fake_attendance
 
-        assert self.boxscore.attendance == 0
+        assert self.boxscore.attendance is None
 
     def test_mlb_first_game_double_header_info(self):
         fields = {
@@ -247,25 +247,25 @@ Second game of doubleheader
         mock_runners = PropertyMock(return_value='')
         type(self.boxscore)._away_inherited_runners = mock_runners
 
-        assert self.boxscore.away_inherited_runners == 0
+        assert self.boxscore.away_inherited_runners is None
 
     def test_invalid_away_inherited_score_returns_default(self):
         mock_score = PropertyMock(return_value='')
         type(self.boxscore)._away_inherited_score = mock_score
 
-        assert self.boxscore.away_inherited_score == 0
+        assert self.boxscore.away_inherited_score is None
 
     def test_invalid_home_inherited_runners_returns_default(self):
         mock_runners = PropertyMock(return_value='')
         type(self.boxscore)._home_inherited_runners = mock_runners
 
-        assert self.boxscore.home_inherited_runners == 0
+        assert self.boxscore.home_inherited_runners is None
 
     def test_invalid_home_inherited_score_returns_default(self):
         mock_score = PropertyMock(return_value='')
         type(self.boxscore)._home_inherited_score = mock_score
 
-        assert self.boxscore.home_inherited_score == 0
+        assert self.boxscore.home_inherited_score is None
 
     def test_no_class_information_returns_dataframe_of_none(self):
         mock_runs = PropertyMock(return_value=None)

--- a/tests/unit/test_mlb_schedule.py
+++ b/tests/unit/test_mlb_schedule.py
@@ -135,3 +135,15 @@ class TestMLBSchedule:
 
         with pytest.raises(ValueError):
             schedule.dataframe
+
+    def test_bad_games_up_returns_default(self):
+        fake_games_up = PropertyMock(return_value='up BAD')
+        type(self.game)._games_behind = fake_games_up
+
+        assert self.game.games_behind is None
+
+    def test_bad_games_ahead_returns_default(self):
+        fake_games_up = PropertyMock(return_value='BAD')
+        type(self.game)._games_behind = fake_games_up
+
+        assert self.game.games_behind is None

--- a/tests/unit/test_mlb_schedule.py
+++ b/tests/unit/test_mlb_schedule.py
@@ -122,8 +122,8 @@ class TestMLBSchedule:
 
     def test_invalid_dataframe_not_included_with_schedule_dataframes(self):
         # If a DataFrame is not valid, it should not be included with the
-        # dataframes property. If no dataframes are present, a ValueError
-        # should be raised.
+        # dataframes property. If no dataframes are present, the DataFrame
+        # should return the default value of None.
         flexmock(Schedule) \
             .should_receive('_pull_schedule') \
             .and_return(None)
@@ -133,8 +133,19 @@ class TestMLBSchedule:
         fake_games = PropertyMock(return_value=fake_game)
         type(schedule).__iter__ = fake_games
 
-        with pytest.raises(ValueError):
-            schedule.dataframe
+        assert schedule.dataframe is None
+
+    def test_no_dataframes_extended_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('HOU')
+
+        fake_game = flexmock(dataframe_extended=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe_extended is None
 
     def test_bad_games_up_returns_default(self):
         fake_games_up = PropertyMock(return_value='up BAD')

--- a/tests/unit/test_mlb_teams.py
+++ b/tests/unit/test_mlb_teams.py
@@ -1,4 +1,5 @@
 from flexmock import flexmock
+from mock import PropertyMock
 from sportsreference.mlb.schedule import Schedule
 from sportsreference.mlb.teams import Team
 
@@ -15,3 +16,25 @@ class TestMLBTeams:
         team = Team(None, 1)
 
         assert len(team.schedule) == 0
+
+    def test_mlb_bad_attribute_property_returns_default(self):
+        flexmock(Team) \
+            .should_receive('_parse_team_data') \
+            .and_return(None)
+        team = Team(None, 1)
+
+        fake_record = PropertyMock(return_value=None)
+        type(team)._extra_inning_record = fake_record
+
+        assert team.extra_inning_wins is None
+
+    def test_mlb_bad_int_property_returns_default(self):
+        flexmock(Team) \
+            .should_receive('_parse_team_data') \
+            .and_return(None)
+        team = Team(None, 1)
+
+        fake_record = PropertyMock(return_value='Bad-Bad')
+        type(team)._extra_inning_record = fake_record
+
+        assert team.extra_inning_wins is None

--- a/tests/unit/test_nba_roster.py
+++ b/tests/unit/test_nba_roster.py
@@ -44,7 +44,7 @@ class TestNBAPlayer:
 
         result = player.field_goal_percentage
 
-        assert result == 0.0
+        assert result is None
 
     @patch('requests.get', side_effect=mock_pyquery)
     def test_invalid_url_returns_none(self, *args, **kwargs):

--- a/tests/unit/test_nba_schedule.py
+++ b/tests/unit/test_nba_schedule.py
@@ -4,7 +4,7 @@ from sportsreference.constants import (AWAY,
                                        HOME,
                                        LOSS,
                                        WIN)
-from sportsreference.nba.schedule import Game
+from sportsreference.nba.schedule import Game, Schedule
 
 
 class TestNBASchedule:
@@ -43,3 +43,27 @@ class TestNBASchedule:
         assert self.game._points_allowed is None
         assert self.game._points_scored is None
         assert self.game.dataframe is None
+
+    def test_no_dataframes_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('DET')
+
+        fake_game = flexmock(dataframe=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe is None
+
+    def test_no_dataframes_extended_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('DET')
+
+        fake_game = flexmock(dataframe_extended=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe_extended is None

--- a/tests/unit/test_ncaab_boxscore.py
+++ b/tests/unit/test_ncaab_boxscore.py
@@ -309,13 +309,13 @@ class TestNCAABBoxscore:
         fake_percentage = PropertyMock(return_value='')
         type(self.boxscore)._home_free_throw_percentage = fake_percentage
 
-        assert self.boxscore.home_free_throw_percentage == 0.0
+        assert self.boxscore.home_free_throw_percentage is None
 
     def test_no_away_free_throw_percentage_returns_default(self):
         fake_percentage = PropertyMock(return_value='')
         type(self.boxscore)._away_free_throw_percentage = fake_percentage
 
-        assert self.boxscore.away_free_throw_percentage == 0.0
+        assert self.boxscore.away_free_throw_percentage is None
 
     def test_empty_boxscore_class_returns_dataframe_of_none(self):
         fake_points = PropertyMock(return_value=None)

--- a/tests/unit/test_ncaab_boxscore.py
+++ b/tests/unit/test_ncaab_boxscore.py
@@ -343,3 +343,9 @@ class TestNCAABBoxscore:
         assert self.boxscore.home_wins == 0
         assert self.boxscore.home_losses == 0
         assert self.boxscore.home_win_percentage == 0.0
+
+    def test_ranking_with_no_boxscores(self):
+        ranking = self.boxscore._parse_ranking('home_ranking',
+                                               MockBoxscore(''))
+
+        assert ranking is None

--- a/tests/unit/test_ncaab_roster.py
+++ b/tests/unit/test_ncaab_roster.py
@@ -31,7 +31,7 @@ class TestNCAABPlayer:
 
         result = player.field_goals
 
-        assert result == 0
+        assert result is None
 
     def test_no_float_returns_default_value(self):
         mock_percentage = PropertyMock(return_value=[''])
@@ -42,7 +42,7 @@ class TestNCAABPlayer:
 
         result = player.field_goal_percentage
 
-        assert result == 0.0
+        assert result is None
 
     @patch('requests.get', side_effect=mock_pyquery)
     def test_invalid_url_returns_none(self, *args, **kwargs):

--- a/tests/unit/test_ncaab_schedule.py
+++ b/tests/unit/test_ncaab_schedule.py
@@ -14,7 +14,7 @@ from sportsreference.ncaab.constants import (CBI_TOURNAMENT,
                                              CIT_TOURNAMENT,
                                              NCAA_TOURNAMENT,
                                              NIT_TOURNAMENT)
-from sportsreference.ncaab.schedule import Game
+from sportsreference.ncaab.schedule import Game, Schedule
 
 
 class TestNCAABSchedule:
@@ -144,6 +144,30 @@ class TestNCAABSchedule:
         assert self.game._home_points is None
         assert self.game._away_points is None
         assert self.game.dataframe_extended is None
+
+    def test_no_dataframes_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('PURDUE')
+
+        fake_game = flexmock(dataframe=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe is None
+
+    def test_no_dataframes_extended_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('PURDUE')
+
+        fake_game = flexmock(dataframe_extended=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe_extended is None
 
 
 class TestNCAABScheduleNames:

--- a/tests/unit/test_ncaaf_boxscore.py
+++ b/tests/unit/test_ncaaf_boxscore.py
@@ -398,3 +398,15 @@ Logos via Sports Logos.net / About logos
         assert self.boxscore._home_points is None
         assert self.boxscore._away_points is None
         assert self.boxscore.dataframe is None
+
+    def test_empty_attribute_returns_none(self):
+        fake_rushes = PropertyMock(return_value=None)
+        type(self.boxscore)._away_rush_attempts = fake_rushes
+
+        assert self.boxscore.away_rush_attempts is None
+
+    def test_non_int_value_returns_none(self):
+        fake_rushes = PropertyMock(return_value='bad')
+        type(self.boxscore)._away_rush_attempts = fake_rushes
+
+        assert self.boxscore.away_rush_attempts is None

--- a/tests/unit/test_ncaaf_schedule.py
+++ b/tests/unit/test_ncaaf_schedule.py
@@ -11,7 +11,7 @@ from sportsreference.constants import (AWAY,
                                        NON_DI,
                                        REGULAR_SEASON,
                                        WIN)
-from sportsreference.ncaaf.schedule import Game
+from sportsreference.ncaaf.schedule import Game, Schedule
 
 
 class TestNCAAFSchedule:
@@ -88,6 +88,30 @@ class TestNCAAFSchedule:
         assert self.game._points_for is None
         assert self.game._points_against is None
         assert self.game.dataframe is None
+
+    def test_no_dataframes_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('PURDUE')
+
+        fake_game = flexmock(dataframe=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe is None
+
+    def test_no_dataframes_extended_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('PURDUE')
+
+        fake_game = flexmock(dataframe_extended=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe_extended is None
 
 
 class TestNCAAFScheduleNames:

--- a/tests/unit/test_ncaaf_teams.py
+++ b/tests/unit/test_ncaaf_teams.py
@@ -16,19 +16,19 @@ class TestNCAAFTeams:
         fake_conference_wins = PropertyMock(return_value='')
         type(self.team)._conference_wins = fake_conference_wins
 
-        assert self.team.conference_wins == 0
+        assert self.team.conference_wins is None
 
     def test_no_conference_losses_data_returns_default(self):
         fake_conference_losses = PropertyMock(return_value='')
         type(self.team)._conference_losses = fake_conference_losses
 
-        assert self.team.conference_losses == 0
+        assert self.team.conference_losses is None
 
     def test_no_conference_percentage_returns_default(self):
         fake_conf_win_percentage = PropertyMock(return_value='')
         type(self.team)._conference_win_percentage = fake_conf_win_percentage
 
-        assert self.team.conference_win_percentage == 0
+        assert self.team.conference_win_percentage is None
 
     def test_ncaaf_schedule_returns_schedule(self):
         flexmock(Schedule) \

--- a/tests/unit/test_nfl_boxscore.py
+++ b/tests/unit/test_nfl_boxscore.py
@@ -164,3 +164,15 @@ class TestNFLBoxscore:
         type(self.boxscore)._away_points = mock_points
 
         assert self.boxscore.dataframe is None
+
+    def test_empty_attribute_returns_none(self):
+        fake_rushes = PropertyMock(return_value=None)
+        type(self.boxscore)._away_rush_attempts = fake_rushes
+
+        assert self.boxscore.away_rush_attempts is None
+
+    def test_non_int_value_returns_none(self):
+        fake_rushes = PropertyMock(return_value='bad')
+        type(self.boxscore)._away_rush_attempts = fake_rushes
+
+        assert self.boxscore.away_rush_attempts is None

--- a/tests/unit/test_nfl_schedule.py
+++ b/tests/unit/test_nfl_schedule.py
@@ -11,7 +11,7 @@ from sportsreference.nfl.constants import (CONF_CHAMPIONSHIP,
                                            DIVISION,
                                            SUPER_BOWL,
                                            WILD_CARD)
-from sportsreference.nfl.schedule import Game
+from sportsreference.nfl.schedule import Game, Schedule
 
 
 YEAR = 2017
@@ -103,3 +103,27 @@ class TestNFLSchedule:
         assert self.game._points_scored is None
         assert self.game._points_allowed is None
         assert self.game.dataframe is None
+
+    def test_no_dataframes_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('DET')
+
+        fake_game = flexmock(dataframe=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe is None
+
+    def test_no_dataframes_extended_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('DET')
+
+        fake_game = flexmock(dataframe_extended=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe_extended is None

--- a/tests/unit/test_nhl_boxscore.py
+++ b/tests/unit/test_nhl_boxscore.py
@@ -169,8 +169,10 @@ class TestNHLBoxscore:
 
         fake_goals = PropertyMock(return_value=goals)
         fake_num_skaters = PropertyMock(return_value=3)
+        fake_num_goalies = PropertyMock(return_value=0)
         type(self.boxscore)._away_game_winning_goals = fake_goals
         type(self.boxscore)._away_skaters = fake_num_skaters
+        type(self.boxscore)._away_goalies = fake_num_goalies
 
         assert self.boxscore.away_game_winning_goals == 1
 
@@ -179,8 +181,10 @@ class TestNHLBoxscore:
 
         fake_assists = PropertyMock(return_value=assists)
         fake_num_skaters = PropertyMock(return_value=3)
+        fake_num_goalies = PropertyMock(return_value=0)
         type(self.boxscore)._away_even_strength_assists = fake_assists
         type(self.boxscore)._away_skaters = fake_num_skaters
+        type(self.boxscore)._away_goalies = fake_num_goalies
 
         assert self.boxscore.away_even_strength_assists == 1
 
@@ -189,8 +193,10 @@ class TestNHLBoxscore:
 
         fake_assists = PropertyMock(return_value=assists)
         fake_num_skaters = PropertyMock(return_value=0)
+        fake_num_goalies = PropertyMock(return_value=0)
         type(self.boxscore)._home_even_strength_assists = fake_assists
         type(self.boxscore)._away_skaters = fake_num_skaters
+        type(self.boxscore)._away_goalies = fake_num_goalies
 
         assert self.boxscore.home_even_strength_assists == 1
 
@@ -199,8 +205,10 @@ class TestNHLBoxscore:
 
         fake_assists = PropertyMock(return_value=assists)
         fake_num_skaters = PropertyMock(return_value=3)
+        fake_num_goalies = PropertyMock(return_value=0)
         type(self.boxscore)._away_power_play_assists = fake_assists
         type(self.boxscore)._away_skaters = fake_num_skaters
+        type(self.boxscore)._away_goalies = fake_num_goalies
 
         assert self.boxscore.away_power_play_assists == 1
 
@@ -209,8 +217,10 @@ class TestNHLBoxscore:
 
         fake_assists = PropertyMock(return_value=assists)
         fake_num_skaters = PropertyMock(return_value=0)
+        fake_num_goalies = PropertyMock(return_value=0)
         type(self.boxscore)._home_power_play_assists = fake_assists
         type(self.boxscore)._away_skaters = fake_num_skaters
+        type(self.boxscore)._away_goalies = fake_num_goalies
 
         assert self.boxscore.home_power_play_assists == 1
 
@@ -219,8 +229,10 @@ class TestNHLBoxscore:
 
         fake_assists = PropertyMock(return_value=assists)
         fake_num_skaters = PropertyMock(return_value=3)
+        fake_num_goalies = PropertyMock(return_value=0)
         type(self.boxscore)._away_short_handed_assists = fake_assists
         type(self.boxscore)._away_skaters = fake_num_skaters
+        type(self.boxscore)._away_goalies = fake_num_goalies
 
         assert self.boxscore.away_short_handed_assists == 1
 
@@ -229,8 +241,10 @@ class TestNHLBoxscore:
 
         fake_assists = PropertyMock(return_value=assists)
         fake_num_skaters = PropertyMock(return_value=0)
+        fake_num_goalies = PropertyMock(return_value=0)
         type(self.boxscore)._home_short_handed_assists = fake_assists
         type(self.boxscore)._away_skaters = fake_num_skaters
+        type(self.boxscore)._away_goalies = fake_num_goalies
 
         assert self.boxscore.home_short_handed_assists == 1
 

--- a/tests/unit/test_nhl_boxscore.py
+++ b/tests/unit/test_nhl_boxscore.py
@@ -298,6 +298,23 @@ Logos via Sports Logos.net / About logos
             result = self.boxscore._parse_game_date_and_location(field, m)
             assert result == value
 
+    def test_limited_game_information(self):
+        fields = {
+            'date': '',
+            'time': '',
+            'attendance': '',
+            'arena': '',
+            'duration': ''
+        }
+
+        mock_field = '\n'
+
+        m = MockBoxscoreData(MockField(mock_field))
+
+        for field, value in fields.items():
+            result = self.boxscore._parse_game_date_and_location(field, m)
+            assert result == value
+
     def test_away_shutout_single_goalies(self):
         shutout = ['1', '0']
 

--- a/tests/unit/test_nhl_schedule.py
+++ b/tests/unit/test_nhl_schedule.py
@@ -8,7 +8,7 @@ from sportsreference.constants import (AWAY,
                                        REGULAR_SEASON,
                                        WIN)
 from sportsreference.nhl.constants import OVERTIME_LOSS, SHOOTOUT
-from sportsreference.nhl.schedule import Game
+from sportsreference.nhl.schedule import Game, Schedule
 
 
 YEAR = 2017
@@ -234,3 +234,27 @@ class TestNHLSchedule:
         assert self.game._goals_scored is None
         assert self.game._goals_allowed is None
         assert self.game.dataframe is None
+
+    def test_no_dataframes_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('DET')
+
+        fake_game = flexmock(dataframe=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe is None
+
+    def test_no_dataframes_extended_returns_none(self):
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+        schedule = Schedule('DET')
+
+        fake_game = flexmock(dataframe_extended=None)
+        fake_games = PropertyMock(return_value=fake_game)
+        type(schedule).__iter__ = fake_games
+
+        assert schedule.dataframe_extended is None

--- a/tests/unit/test_nhl_schedule.py
+++ b/tests/unit/test_nhl_schedule.py
@@ -90,145 +90,145 @@ class TestNHLSchedule:
         fake_shots = PropertyMock(return_value='')
         type(self.game)._shots_on_goal = fake_shots
 
-        assert self.game.shots_on_goal == 0
+        assert self.game.shots_on_goal is None
 
     def test_bad_penalties_in_minutes_returns_default_number(self):
         fake_penalties = PropertyMock(return_value='')
         type(self.game)._penalties_in_minutes = fake_penalties
 
-        assert self.game.penalties_in_minutes == 0
+        assert self.game.penalties_in_minutes is None
 
     def test_bad_power_play_goals_returns_default_number(self):
         fake_power_play_goals = PropertyMock(return_value='')
         type(self.game)._power_play_goals = fake_power_play_goals
 
-        assert self.game.power_play_goals == 0
+        assert self.game.power_play_goals is None
 
     def test_bad_power_play_opportunities_returns_default_number(self):
         fake_power_play_opps = PropertyMock(return_value='')
         type(self.game)._power_play_opportunities = fake_power_play_opps
 
-        assert self.game.power_play_opportunities == 0
+        assert self.game.power_play_opportunities is None
 
     def test_bad_short_handed_goals_returns_default_number(self):
         fake_goals = PropertyMock(return_value='')
         type(self.game)._short_handed_goals = fake_goals
 
-        assert self.game.short_handed_goals == 0
+        assert self.game.short_handed_goals is None
 
     def test_bad_opp_shots_on_goal_returns_default_number(self):
         fake_shots = PropertyMock(return_value='')
         type(self.game)._opp_shots_on_goal = fake_shots
 
-        assert self.game.opp_shots_on_goal == 0
+        assert self.game.opp_shots_on_goal is None
 
     def test_bad_opp_penalties_in_minutes_returns_default_number(self):
         fake_penalties = PropertyMock(return_value='')
         type(self.game)._opp_penalties_in_minutes = fake_penalties
 
-        assert self.game.opp_penalties_in_minutes == 0
+        assert self.game.opp_penalties_in_minutes is None
 
     def test_bad_opp_power_play_goals_returns_default_number(self):
         fake_power_play_goals = PropertyMock(return_value='')
         type(self.game)._opp_power_play_goals = fake_power_play_goals
 
-        assert self.game.opp_power_play_goals == 0
+        assert self.game.opp_power_play_goals is None
 
     def test_bad_opp_power_play_opportunities_returns_default_number(self):
         fake_power_play_opps = PropertyMock(return_value='')
         type(self.game)._opp_power_play_opportunities = fake_power_play_opps
 
-        assert self.game.opp_power_play_opportunities == 0
+        assert self.game.opp_power_play_opportunities is None
 
     def test_bad_opp_short_handed_goals_returns_default_number(self):
         fake_goals = PropertyMock(return_value='')
         type(self.game)._opp_short_handed_goals = fake_goals
 
-        assert self.game.opp_short_handed_goals == 0
+        assert self.game.opp_short_handed_goals is None
 
     def test_bad_penalties_in_minutes_returns_default_number(self):
         fake_penalties = PropertyMock(return_value='')
         type(self.game)._penalties_in_minutes = fake_penalties
 
-        assert self.game.penalties_in_minutes == 0
+        assert self.game.penalties_in_minutes is None
 
     def test_bad_power_play_goals_returns_default_number(self):
         fake_power_play_goals = PropertyMock(return_value='')
         type(self.game)._power_play_goals = fake_power_play_goals
 
-        assert self.game.power_play_goals == 0
+        assert self.game.power_play_goals is None
 
     def test_bad_power_play_opportunities_returns_default_number(self):
         fake_power_play_opps = PropertyMock(return_value='')
         type(self.game)._power_play_opportunities = fake_power_play_opps
 
-        assert self.game.power_play_opportunities == 0
+        assert self.game.power_play_opportunities is None
 
     def test_bad_corsi_for_returns_default_number(self):
         fake_corsi = PropertyMock(return_value='')
         type(self.game)._corsi_for = fake_corsi
 
-        assert self.game.corsi_for == 0
+        assert self.game.corsi_for is None
 
     def test_bad_corsi_against_returns_default_number(self):
         fake_corsi = PropertyMock(return_value='')
         type(self.game)._corsi_against = fake_corsi
 
-        assert self.game.corsi_against == 0
+        assert self.game.corsi_against is None
 
     def test_bad_corsi_for_percentage_returns_default_number(self):
         fake_corsi = PropertyMock(return_value='')
         type(self.game)._corsi_for_percentage = fake_corsi
 
-        assert self.game.corsi_for_percentage == 0.0
+        assert self.game.corsi_for_percentage is None
 
     def test_bad_fenwick_for_returns_default_number(self):
         fake_fenwick = PropertyMock(return_value='')
         type(self.game)._fenwick_for = fake_fenwick
 
-        assert self.game.fenwick_for == 0
+        assert self.game.fenwick_for is None
 
     def test_bad_fenwick_against_returns_default_number(self):
         fake_fenwick = PropertyMock(return_value='')
         type(self.game)._fenwick_against = fake_fenwick
 
-        assert self.game.fenwick_against == 0
+        assert self.game.fenwick_against is None
 
     def test_bad_fenwick_for_percentage_returns_default_number(self):
         fake_fenwick = PropertyMock(return_value='')
         type(self.game)._fenwick_for_percentage = fake_fenwick
 
-        assert self.game.fenwick_for_percentage == 0.0
+        assert self.game.fenwick_for_percentage is None
 
     def test_bad_faceoff_wins_returns_default_number(self):
         fake_faceoff = PropertyMock(return_value='')
         type(self.game)._faceoff_wins = fake_faceoff
 
-        assert self.game.faceoff_wins == 0
+        assert self.game.faceoff_wins is None
 
     def test_bad_faceoff_losses_returns_default_number(self):
         fake_faceoff = PropertyMock(return_value='')
         type(self.game)._faceoff_losses = fake_faceoff
 
-        assert self.game.faceoff_losses == 0
+        assert self.game.faceoff_losses is None
 
     def test_bad_faceoff_win_percentage_returns_default_number(self):
         fake_faceoff = PropertyMock(return_value='')
         type(self.game)._faceoff_win_percentage = fake_faceoff
 
-        assert self.game.faceoff_win_percentage == 0.0
+        assert self.game.faceoff_win_percentage is None
 
     def test_bad_offensive_zone_start_percentage_returns_default_number(self):
         fake_start = PropertyMock(return_value='')
         type(self.game)._offensive_zone_start_percentage = fake_start
 
-        assert self.game.offensive_zone_start_percentage == 0.0
+        assert self.game.offensive_zone_start_percentage is None
 
     def test_bad_pdo_returns_default_number(self):
         fake_pdo = PropertyMock(return_value='')
         type(self.game)._pdo = fake_pdo
 
-        assert self.game.pdo == 0.0
+        assert self.game.pdo is None
 
     def test_empty_game_class_returns_dataframe_of_none(self):
         assert self.game._goals_scored is None

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -198,6 +198,19 @@ class TestUtils:
                                     'abbreviation')
         assert result == expected
 
+    def test_parse_field_returns_none_on_index_error(self):
+        parsing_scheme = {'batters_used': 'td[data-stat="batters_used"]:first'}
+        html_string = '''<td class="right " data-stat="batters_used">32</td>
+<td class="right " data-stat="age_bat">29.1</td>
+<td class="right " data-stat="runs_per_game">4.10</td>'''
+        expected = None
+
+        result = utils._parse_field(parsing_scheme,
+                                    MockHtml(html_string, [expected]),
+                                    'batters_used',
+                                    index=3)
+        assert result == expected
+
     def test__parse_field_returns_value_for_non_abbreviation(self):
         parsing_scheme = {'batters_used': 'td[data-stat="batters_used"]:first'}
         html_string = '''<td class="right " data-stat="batters_used">32</td>


### PR DESCRIPTION
All class properties should include error parsing to handle cases where data on [sports-reference](http://www.sports-reference.com) isn't properly formatted or is incomplete. This enables long-running scripts to collect all of the desired data instead of terminating early and losing any progress due to a single error on a webpage. In general, when a value can't be parsed, a default value of `None` is used for the property value to distinguish an absence of a value and a `0` for that stat. For example, a team who scores 0 touchdowns is different from a team that didn't have the number of touchdowns recorded, as it is entirely possible they scored at least one during the game.

Fixes #3.

Signed-Off-By: Robert Clark <robdclark@outlook.com>