### PR TITLE
Fix game info parsing

### DIFF
--- a/sportsreference/mlb/constants.py
+++ b/sportsreference/mlb/constants.py
@@ -140,12 +140,7 @@ ELEMENT_INDEX = {
 }
 
 BOXSCORE_SCHEME = {
-    'date': 'div[class="scorebox_meta"]',
-    'time': 'div[class="scorebox_meta"]',
-    'attendance': 'div[class="scorebox_meta"]',
-    'venue': 'div[class="scorebox_meta"]',
-    'time_of_day': 'div[class="scorebox_meta"]',
-    'duration': 'div[class="scorebox_meta"]',
+    'game_info': 'div[class="scorebox_meta"]',
     'away_name': 'a[itemprop="name"]:first',
     'home_name': 'a[itemprop="name"]:last',
     'winner': 'td[data-stat=""]',

--- a/sportsreference/nba/boxscore.py
+++ b/sportsreference/nba/boxscore.py
@@ -159,6 +159,8 @@ class Boxscore(object):
         scheme = BOXSCORE_SCHEME[field]
         items = [i.text() for i in boxscore(scheme).items()]
         game_info = items[0].split('\n')
+        if len(game_info) < 3 and field == 'location':
+            return None
         return game_info[BOXSCORE_ELEMENT_INDEX[field]]
 
     def _parse_name(self, field, boxscore):

--- a/sportsreference/ncaab/boxscore.py
+++ b/sportsreference/ncaab/boxscore.py
@@ -167,6 +167,8 @@ class Boxscore(object):
         scheme = BOXSCORE_SCHEME[field]
         items = [i.text() for i in boxscore(scheme).items()]
         game_info = items[0].split('\n')
+        if len(game_info) < 3 and field == 'location':
+            return None
         return game_info[BOXSCORE_ELEMENT_INDEX[field]]
 
     def _parse_name(self, field, boxscore):

--- a/sportsreference/nfl/constants.py
+++ b/sportsreference/nfl/constants.py
@@ -76,11 +76,7 @@ SCHEDULE_SCHEME = {
 }
 
 BOXSCORE_SCHEME = {
-    'date': 'div[class="scorebox_meta"]:first',
-    'time': 'div[class="scorebox_meta"]:first',
-    'stadium': 'div[class="scorebox_meta"]:first',
-    'attendance': 'div[class="scorebox_meta"]:first',
-    'duration': 'div[class="scorebox_meta"]:first',
+    'game_info': 'div[class="scorebox_meta"]:first',
     'home_name': 'a[itemprop="name"]:first',
     'away_name': 'a[itemprop="name"]:last',
     'away_points': 'div[class="scorebox"] div[class="score"]',

--- a/sportsreference/nhl/constants.py
+++ b/sportsreference/nhl/constants.py
@@ -62,11 +62,7 @@ SCHEDULE_SCHEME = {
 }
 
 BOXSCORE_SCHEME = {
-    'date': 'div[class="scorebox_meta"]',
-    'time': 'div[class="scorebox_meta"]',
-    'arena': 'div[class="scorebox_meta"]',
-    'attendance': 'div[class="scorebox_meta"]',
-    'duration': 'div[class="scorebox_meta"]',
+    'game_info': 'div[class="scorebox_meta"]',
     'away_name': 'a[itemprop="name"]:first',
     'home_name': 'a[itemprop="name"]:last',
     'away_skaters': 'table[class="sortable stats_table"]:first tbody tr',

--- a/tests/unit/test_nba_boxscore.py
+++ b/tests/unit/test_nba_boxscore.py
@@ -13,6 +13,25 @@ class MockName:
         return self._name
 
 
+class MockField:
+    def __init__(self, field):
+        self._field = field
+
+    def text(self):
+        return self._field
+
+
+class MockBoxscoreData:
+    def __init__(self, fields):
+        self._fields = fields
+
+    def __call__(self, field):
+        return self
+
+    def items(self):
+        return [self._fields]
+
+
 def mock_pyquery(url):
     class MockPQ:
         def __init__(self, html_contents):
@@ -180,3 +199,35 @@ class TestNBABoxscore:
         type(self.boxscore)._home_points = mock_points
 
         assert self.boxscore.dataframe is None
+
+    def test_nba_game_info(self):
+        fields = {
+            'date': '7:30 PM, November 9, 2018',
+            'location': 'State Farm Arena, Atlanta, Georgia'
+        }
+
+        mock_field = """7:30 PM, November 9, 2018
+State Farm Arena, Atlanta, Georgia
+Logos via Sports Logos.net / About logos
+"""
+
+        m = MockBoxscoreData(MockField(mock_field))
+
+        for field, value in fields.items():
+            result = self.boxscore._parse_game_date_and_location(field, m)
+            assert value == result
+
+    def test_nba_partial_game_info(self):
+        fields = {
+            'date': '7:30 PM, November 9, 2018',
+            'location': None
+        }
+
+        mock_field = """7:30 PM, November 9, 2018
+Logos via Sports Logos.net / About logos"""
+
+        m = MockBoxscoreData(MockField(mock_field))
+
+        for field, value in fields.items():
+            result = self.boxscore._parse_game_date_and_location(field, m)
+            assert value == result

--- a/tests/unit/test_ncaab_boxscore.py
+++ b/tests/unit/test_ncaab_boxscore.py
@@ -24,6 +24,25 @@ class MockName:
         return self._name.replace('<a>cbb/schools</a>', '')
 
 
+class MockField:
+    def __init__(self, field):
+        self._field = field
+
+    def text(self):
+        return self._field
+
+
+class MockBoxscoreData:
+    def __init__(self, fields):
+        self._fields = fields
+
+    def __call__(self, field):
+        return self
+
+    def items(self):
+        return [self._fields]
+
+
 def mock_pyquery(url):
     class MockPQ:
         def __init__(self, html_contents):
@@ -349,3 +368,35 @@ class TestNCAABBoxscore:
                                                MockBoxscore(''))
 
         assert ranking is None
+
+    def test_ncaab_game_info(self):
+        fields = {
+            'date': 'November 9, 2018',
+            'location': 'WVU Coliseum, Morgantown, West Virginia'
+        }
+
+        mock_field = """November 9, 2018
+WVU Coliseum, Morgantown, West Virginia
+Logos via Sports Logos.net / About logos
+"""
+
+        m = MockBoxscoreData(MockField(mock_field))
+
+        for field, value in fields.items():
+            result = self.boxscore._parse_game_date_and_location(field, m)
+            assert value == result
+
+    def test_ncaab_partial_game_info(self):
+        fields = {
+            'date': 'November 9, 2018',
+            'location': None
+        }
+
+        mock_field = """November 9, 2018
+Logos via Sports Logos.net / About logos"""
+
+        m = MockBoxscoreData(MockField(mock_field))
+
+        for field, value in fields.items():
+            result = self.boxscore._parse_game_date_and_location(field, m)
+            assert value == result

--- a/tests/unit/test_nfl_boxscore.py
+++ b/tests/unit/test_nfl_boxscore.py
@@ -14,6 +14,25 @@ class MockName:
         return self._name
 
 
+class MockField:
+    def __init__(self, field):
+        self._field = field
+
+    def text(self):
+        return self._field
+
+
+class MockBoxscoreData:
+    def __init__(self, fields):
+        self._fields = fields
+
+    def __call__(self, field):
+        return self
+
+    def items(self):
+        return [self._fields]
+
+
 def read_file(filename):
     filepath = join(dirname(__file__), 'nfl', filename)
     return open(filepath, 'r').read()
@@ -186,3 +205,47 @@ class TestNFLBoxscore:
         type(self.boxscore)._away_rush_attempts = fake_rushes
 
         assert self.boxscore.away_rush_attempts is None
+
+    def test_nfl_game_information(self):
+        fields = {
+            'attendance': 62881,
+            'date': 'Thursday Nov 8, 2018',
+            'duration': '2:49',
+            'stadium': 'Heinz Field',
+            'time': '8:20pm'
+        }
+
+        mock_field = """Thursday Nov 8, 2018
+Start Time: 8:20pm
+Stadium: Heinz Field
+Attendance: 62,881
+Time of Game: 2:49
+Logos via Sports Logos.net / About logos
+"""
+
+        m = MockBoxscoreData(MockField(mock_field))
+
+        self.boxscore._parse_game_date_and_location(m)
+        for field, value in fields.items():
+            assert getattr(self.boxscore, field) == value
+
+    def test_nfl_game_limited_information(self):
+        fields = {
+            'attendance': 22000,
+            'date': 'Sunday Sep 8, 1940',
+            'duration': None,
+            'stadium': 'Forbes Field',
+            'time': None
+        }
+
+        mock_field = """Sunday Sep 8, 1940
+Stadium: Forbes Field
+Attendance: 22,000
+Logos via Sports Logos.net / About logos
+"""
+
+        m = MockBoxscoreData(MockField(mock_field))
+
+        self.boxscore._parse_game_date_and_location(m)
+        for field, value in fields.items():
+            assert getattr(self.boxscore, field) == value

--- a/tests/unit/test_nhl_boxscore.py
+++ b/tests/unit/test_nhl_boxscore.py
@@ -255,11 +255,12 @@ class TestNHLBoxscore:
 
     def test_regular_season_information(self):
         fields = {
-            'date': 'October 5, 2017, 7:00 PM',
-            'time': 'October 5, 2017, 7:00 PM',
-            'attendance': 'Attendance: 17,565',
-            'arena': 'Arena: TD Garden',
-            'duration': 'Game Duration: 2:39'
+            'date': 'October 5, 2017',
+            'playoff_round': None,
+            'time': '7:00 PM',
+            'attendance': 17565,
+            'arena': 'TD Garden',
+            'duration': '2:39'
         }
 
         mock_field = """October 5, 2017, 7:00 PM
@@ -271,17 +272,18 @@ Logos via Sports Logos.net / About logos
 
         m = MockBoxscoreData(MockField(mock_field))
 
+        self.boxscore._parse_game_date_and_location(m)
         for field, value in fields.items():
-            result = self.boxscore._parse_game_date_and_location(field, m)
-            assert result == value
+            assert getattr(self.boxscore, field) == value
 
     def test_playoffs_information(self):
         fields = {
-            'date': 'June 7, 2018, 8:00 PM',
-            'time': 'June 7, 2018, 8:00 PM',
-            'attendance': 'Attendance: 18,529',
-            'arena': 'Arena: T-Mobile Arena',
-            'duration': 'Game Duration: 2:45'
+            'date': 'June 7, 2018',
+            'playoff_round': 'Stanley Cup Final',
+            'time': '8:00 PM',
+            'attendance': 18529,
+            'arena': 'T-Mobile Arena',
+            'duration': '2:45'
         }
 
         mock_field = """June 7, 2018, 8:00 PM
@@ -294,26 +296,49 @@ Logos via Sports Logos.net / About logos
 
         m = MockBoxscoreData(MockField(mock_field))
 
+        self.boxscore._parse_game_date_and_location(m)
         for field, value in fields.items():
-            result = self.boxscore._parse_game_date_and_location(field, m)
-            assert result == value
+            assert getattr(self.boxscore, field) == value
 
-    def test_limited_game_information(self):
+    def test_no_game_information(self):
         fields = {
             'date': '',
-            'time': '',
-            'attendance': '',
-            'arena': '',
-            'duration': ''
+            'playoff_round': None,
+            'time': None,
+            'attendance': None,
+            'arena': None,
+            'duration': None
         }
 
         mock_field = '\n'
 
         m = MockBoxscoreData(MockField(mock_field))
 
+        self.boxscore._parse_game_date_and_location(m)
         for field, value in fields.items():
-            result = self.boxscore._parse_game_date_and_location(field, m)
-            assert result == value
+            assert getattr(self.boxscore, field) == value
+
+    def test_limited_game_information(self):
+        fields = {
+            'date': 'June 7, 2018',
+            'playoff_round': 'Stanley Cup Final',
+            'time': None,
+            'attendance': None,
+            'arena': 'T-Mobile Arena',
+            'duration': None
+        }
+
+        mock_field = """June 7, 2018
+Stanley Cup Final
+Arena: T-Mobile Arena
+Logos via Sports Logos.net / About logos
+"""
+
+        m = MockBoxscoreData(MockField(mock_field))
+
+        self.boxscore._parse_game_date_and_location(m)
+        for field, value in fields.items():
+            assert getattr(self.boxscore, field) == value
 
     def test_away_shutout_single_goalies(self):
         shutout = ['1', '0']


### PR DESCRIPTION
Now able to more accurately parse historic game information when less data is displayed on a boxscore page.

Fixes #5.

Signed-Off-By: Robert Clark <robdclark@outlook.com>