### PR TITLE
Fix issue pulling NCAAB rankings

### DIFF
--- a/sportsreference/ncaab/constants.py
+++ b/sportsreference/ncaab/constants.py
@@ -317,7 +317,7 @@ SCHEDULE_URL = ('http://www.sports-reference.com/cbb/schools/%s/'
 BOXSCORE_URL = 'http://www.sports-reference.com/cbb/boxscores/%s.html'
 BOXSCORES_URL = ('https://www.sports-reference.com/cbb/boxscores/index.cgi?'
                  'month=%s&day=%s&year=%s')
-RANKINGS_URL = 'https://www.sports-reference.com/cbb/seasons/%s-polls.html'
+RANKINGS_URL = 'https://www.sports-reference.com/cbb/seasons/%s-polls-old.html'
 CONFERENCES_URL = 'https://www.sports-reference.com/cbb/seasons/%s.html'
 CONFERENCE_URL = 'https://www.sports-reference.com/cbb/conferences/%s/%s.html'
 PLAYER_URL = 'https://www.sports-reference.com/cbb/players/%s.html'


### PR DESCRIPTION
sports-reference.com changed the layout of the NCAAB rankings page which prevented any rankings from being properly parsed and saved in the Rankings class. They still have an old version which is accessible by appending '-old' to the URL. Targetting this new page allows the original rankings logic to be used without making any changes.

Fixes #13

Signed-Off-By: Robert Clark <robdclark@outlook.com>