### PR TITLE
Fix issue pulling stats from blank players

### DIFF
--- a/sportsreference/mlb/roster.py
+++ b/sportsreference/mlb/roster.py
@@ -286,7 +286,9 @@ class Player(object):
             Returns an updated version of the passed all_stats_dict which
             includes more metrics from the provided table.
         """
-        most_recent_season = ''
+        most_recent_season = self._most_recent_season
+        if not table_rows:
+            table_rows = []
         for row in table_rows:
             # For now, remove minor-league stats
             if 'class="minors_table hidden"' in str(row) or \
@@ -300,6 +302,8 @@ class Player(object):
                 all_stats_dict[season] = {'data': str(row)}
             most_recent_season = season
         self._most_recent_season = most_recent_season
+        if not career_stats:
+            return all_stats_dict
         try:
             all_stats_dict['career']['data'] += str(next(career_stats))
         except KeyError:
@@ -330,13 +334,8 @@ class Player(object):
 
         for table_id in ['batting_standard', 'standard_fielding',
                          'appearances', 'pitching_standard']:
-            try:
-                table_items = utils._get_stats_table(player_info,
-                                                     'table#%s' % table_id)
-            # Error is thrown when player does not have corresponding table,
-            # such as an outfielder not having any pitching stats.
-            except (ParserError, XMLSyntaxError):
-                continue
+            table_items = utils._get_stats_table(player_info,
+                                                 'table#%s' % table_id)
             career_items = utils._get_stats_table(player_info,
                                                   'table#%s' % table_id,
                                                   footer=True)

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -288,7 +288,9 @@ class Player(object):
             Returns an updated version of the passed all_stats_dict which
             includes more metrics from the provided table.
         """
-        most_recent_season = ''
+        most_recent_season = self._most_recent_season
+        if not table_rows:
+            table_rows = []
         for row in table_rows:
             season = self._parse_season(row)
             try:
@@ -297,6 +299,8 @@ class Player(object):
                 all_stats_dict[season] = {'data': str(row)}
             most_recent_season = season
         self._most_recent_season = most_recent_season
+        if not career_stats:
+            return all_stats_dict
         try:
             all_stats_dict['career']['data'] += str(next(career_stats))
         except KeyError:
@@ -327,16 +331,11 @@ class Player(object):
 
         for table_id in ['totals', 'advanced', 'shooting', 'advanced_pbp',
                          'all_salaries']:
-            try:
-                table_items = utils._get_stats_table(player_info,
-                                                     'table#%s' % table_id)
-                career_items = utils._get_stats_table(player_info,
-                                                      'table#%s' % table_id,
-                                                      footer=True)
-            # Error is thrown when player does not have the corresponding
-            # table, such as a rookie.
-            except (ParserError, XMLSyntaxError):
-                continue
+            table_items = utils._get_stats_table(player_info,
+                                                 'table#%s' % table_id)
+            career_items = utils._get_stats_table(player_info,
+                                                  'table#%s' % table_id,
+                                                  footer=True)
             all_stats_dict = self._combine_season_stats(table_items,
                                                         career_items,
                                                         all_stats_dict)

--- a/sportsreference/ncaab/roster.py
+++ b/sportsreference/ncaab/roster.py
@@ -213,7 +213,9 @@ class Player(object):
             Returns an updated version of the passed all_stats_dict which
             includes more metrics from the provided table.
         """
-        most_recent_season = ''
+        most_recent_season = self._most_recent_season
+        if not table_rows:
+            table_rows = []
         for row in table_rows:
             season = self._parse_season(row)
             try:
@@ -222,6 +224,8 @@ class Player(object):
                 all_stats_dict[season] = {'data': str(row)}
             most_recent_season = season
         self._most_recent_season = most_recent_season
+        if not career_stats:
+            return all_stats_dict
         try:
             all_stats_dict['career']['data'] += str(next(career_stats))
         except KeyError:

--- a/sportsreference/ncaaf/roster.py
+++ b/sportsreference/ncaaf/roster.py
@@ -207,7 +207,9 @@ class Player(object):
             Returns an updated version of the passed all_stats_dict which
             includes more metrics from the provided table.
         """
-        most_recent_season = ''
+        most_recent_season = self._most_recent_season
+        if not table_rows:
+            table_rows = []
         for row in table_rows:
             season = self._parse_season(row)
             try:
@@ -216,6 +218,8 @@ class Player(object):
                 all_stats_dict[season] = {'data': str(row)}
             most_recent_season = season
         self._most_recent_season = most_recent_season
+        if not career_stats:
+            return all_stats_dict
         try:
             all_stats_dict['career']['data'] += str(next(career_stats))
         except KeyError:
@@ -245,13 +249,8 @@ class Player(object):
         all_stats_dict = {}
 
         for table_id in ['passing', 'rushing', 'defense', 'scoring']:
-            try:
-                table_items = utils._get_stats_table(player_info,
-                                                     'table#%s' % table_id)
-            # Error is thrown when player does not have the corresponding
-            # table, such as a quarterback not having any kicking stats.
-            except (ParserError, XMLSyntaxError):
-                continue
+            table_items = utils._get_stats_table(player_info,
+                                                 'table#%s' % table_id)
             career_items = utils._get_stats_table(player_info,
                                                   'table#%s' % table_id,
                                                   footer=True)

--- a/sportsreference/nfl/roster.py
+++ b/sportsreference/nfl/roster.py
@@ -292,7 +292,9 @@ class Player(object):
             Returns an updated version of the passed all_stats_dict which
             includes more metrics from the provided table.
         """
-        most_recent_season = ''
+        most_recent_season = self._most_recent_season
+        if not table_rows:
+            table_rows = []
         for row in table_rows:
             season = self._parse_season(row)
             try:
@@ -301,6 +303,8 @@ class Player(object):
                 all_stats_dict[season] = {'data': str(row)}
             most_recent_season = season
         self._most_recent_season = most_recent_season
+        if not career_stats:
+            return all_stats_dict
         try:
             all_stats_dict['career']['data'] += str(next(career_stats))
         except KeyError:
@@ -337,13 +341,8 @@ class Player(object):
         for table_id in ['passing', 'passing_advanced',
                          'rushing_and_receiving', 'defense', 'returns',
                          'kicking']:
-            try:
-                table_items = utils._get_stats_table(player_info,
-                                                     'table#%s' % table_id)
-            # Error is thrown when player does not have the corresponding
-            # table, such as a quarterback not having any kicking stats.
-            except (ParserError, XMLSyntaxError):
-                continue
+            table_items = utils._get_stats_table(player_info,
+                                                 'table#%s' % table_id)
             career_items = utils._get_stats_table(player_info,
                                                   'table#%s' % table_id,
                                                   footer=True)

--- a/sportsreference/nhl/roster.py
+++ b/sportsreference/nhl/roster.py
@@ -247,7 +247,9 @@ class Player(object):
             Returns an updated version of the passed all_stats_dict which
             includes more metrics from the provided table.
         """
-        most_recent_season = ''
+        most_recent_season = self._most_recent_season
+        if not table_rows:
+            table_rows = []
         for row in table_rows:
             season = self._parse_season(row)
             try:
@@ -256,6 +258,8 @@ class Player(object):
                 all_stats_dict[season] = {'data': str(row)}
             most_recent_season = season
         self._most_recent_season = most_recent_season
+        if not career_stats:
+            return all_stats_dict
         try:
             all_stats_dict['career']['data'] += str(next(career_stats))
         except KeyError:
@@ -286,13 +290,8 @@ class Player(object):
 
         for table_id in ['stats_basic_plus_nhl', 'skaters_advanced',
                          'stats_misc_plus_nhl', 'stats_goalie_situational']:
-            try:
-                table_items = utils._get_stats_table(player_info,
-                                                     'table#%s' % table_id)
-            # Error is thrown when player does not have the corresponding
-            # table, such as a quarterback not having any kicking stats.
-            except (ParserError, XMLSyntaxError):
-                continue
+            table_items = utils._get_stats_table(player_info,
+                                                 'table#%s' % table_id)
             career_items = utils._get_stats_table(player_info,
                                                   'table#%s' % table_id,
                                                   footer=True)

--- a/sportsreference/utils.py
+++ b/sportsreference/utils.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime
+from lxml.etree import ParserError, XMLSyntaxError
 from pyquery import PyQuery as pq
 
 
@@ -216,7 +217,10 @@ def _get_stats_table(html_page, div, footer=False):
         A generator of all row items in a given table.
     """
     stats_html = html_page(div)
-    stats_table = pq(_remove_html_comment_tags(stats_html))
+    try:
+        stats_table = pq(_remove_html_comment_tags(stats_html))
+    except (ParserError, XMLSyntaxError):
+        return None
     if footer:
         teams_list = stats_table('tfoot tr').items()
     else:

--- a/tests/unit/test_ncaab_roster.py
+++ b/tests/unit/test_ncaab_roster.py
@@ -61,3 +61,9 @@ class TestNCAABPlayer:
         result = _cleanup(None)
 
         assert result == ''
+
+    def test_player_with_no_stats(self):
+        player = Player(None)
+        result = player._combine_season_stats(None, None, {})
+
+        assert result == {}


### PR DESCRIPTION
The Roster class currently throws an error whenever a player doesn't have any stats associated with him/her because it can't parse a table that doesn't exist. Now, the code will attempt to parse as much information as possible and store it in the class properties.

Fixes #29

Signed-Off-By: Robert Clark <robdclark@outlook.com>