### PR TITLE
Create slim parameter for Roster class

### DIFF
--- a/sportsreference/mlb/roster.py
+++ b/sportsreference/mlb/roster.py
@@ -1461,10 +1461,19 @@ class Roster(object):
     year : string (optional)
         The 4-digit year to pull the roster from, such as '2018'. If left
         blank, defaults to the most recent season.
+    slim : boolean (optional)
+        Set to True to return a limited subset of player information including
+        the name and player ID for each player as opposed to all of their
+        respective stats which greatly reduces the time to return a response if
+        just the names and IDs are desired. Defaults to False.
     """
-    def __init__(self, team, year=None):
+    def __init__(self, team, year=None, slim=False):
         self._team = team
-        self._players = []
+        self._slim = slim
+        if slim:
+            self._players = {}
+        else:
+            self._players = []
 
         self._find_players(year)
 
@@ -1531,6 +1540,27 @@ class Roster(object):
         name = re.sub(r'.*/players/./', '', str(name_tag))
         return re.sub(r'\.shtml.*', '', name)
 
+    def _get_name(self, player):
+        """
+        Parse the player's name.
+
+        Given a PyQuery object representing a single player on the team roster,
+        parse the player ID and return it as a string.
+
+        Parameters
+        ----------
+        player : PyQuery object
+            A PyQuery object representing the player information from the
+            roster table.
+
+        Returns
+        -------
+        string
+            Returns a string of the player's name.
+        """
+        name_tag = player('td[data-stat="player"] a')
+        return name_tag.text()
+
     def _find_players(self, year):
         """
         Find all player IDs for the requested team.
@@ -1561,8 +1591,12 @@ class Roster(object):
             if 'class="thead"' in str(player):
                 continue
             player_id = self._get_id(player)
-            player_instance = Player(player_id)
-            self._players.append(player_instance)
+            if self._slim:
+                name = self._get_name(player)
+                self._players[player_id] = name
+            else:
+                player_instance = Player(player_id)
+                self._players.append(player_instance)
             players_parsed.append(player_id)
         for player in page('table#team_pitching tbody tr').items():
             if 'class="thead"' in str(player):
@@ -1572,13 +1606,20 @@ class Roster(object):
             # is often the case with National League pitchers.
             if player_id in players_parsed:
                 continue
-            player_instance = Player(player_id)
-            self._players.append(player_instance)
+            if self._slim:
+                name = self._get_name(player)
+                self._players[player_id] = name
+            else:
+                player_instance = Player(player_id)
+                self._players.append(player_instance)
 
     @property
     def players(self):
         """
         Returns a ``list`` of player instances for each player on the requested
-        team's roster.
+        team's roster if the ``slim`` property is False when calling the Roster
+        class. If the ``slim`` property is True, returns a ``dictionary`` where
+        each key is a string of the player's ID and each value is the player's
+        first and last name as listed on the roster page.
         """
         return self._players

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -1502,10 +1502,19 @@ class Roster(object):
     year : string (optional)
         The 4-digit year to pull the roster from, such as '2018'. If left
         blank, defaults to the most recent season.
+    slim : boolean (optional)
+        Set to True to return a limited subset of player information including
+        the name and player ID for each player as opposed to all of their
+        respective stats which greatly reduces the time to return a response if
+        just the names and IDs are desired. Defaults to False.
     """
-    def __init__(self, team, year=None):
+    def __init__(self, team, year=None, slim=False):
         self._team = team
-        self._players = []
+        self._slim = slim
+        if slim:
+            self._players = {}
+        else:
+            self._players = []
 
         self._find_players(year)
 
@@ -1572,6 +1581,27 @@ class Roster(object):
         name = re.sub(r'.*/players/./', '', str(name_tag))
         return re.sub(r'\.html.*', '', name)
 
+    def _get_name(self, player):
+        """
+        Parse the player's name.
+
+        Given a PyQuery object representing a single player on the team roster,
+        parse the player ID and return it as a string.
+
+        Parameters
+        ----------
+        player : PyQuery object
+            A PyQuery object representing the player information from the
+            roster table.
+
+        Returns
+        -------
+        string
+            Returns a string of the player's name.
+        """
+        name_tag = player('td[data-stat="player"] a')
+        return name_tag.text()
+
     def _find_players(self, year):
         """
         Find all player IDs for the requested team.
@@ -1599,13 +1629,20 @@ class Roster(object):
         players = page('table#roster tbody tr').items()
         for player in players:
             player_id = self._get_id(player)
-            player_instance = Player(player_id)
-            self._players.append(player_instance)
+            if self._slim:
+                name = self._get_name(player)
+                self._players[player_id] = name
+            else:
+                player_instance = Player(player_id)
+                self._players.append(player_instance)
 
     @property
     def players(self):
         """
         Returns a ``list`` of player instances for each player on the requested
-        team's roster.
+        team's roster if the ``slim`` property is False when calling the Roster
+        class. If the ``slim`` property is True, returns a ``dictionary`` where
+        each key is a string of the player's ID and each value is the player's
+        first and last name as listed on the roster page.
         """
         return self._players

--- a/sportsreference/ncaaf/roster.py
+++ b/sportsreference/ncaaf/roster.py
@@ -899,10 +899,19 @@ class Roster(object):
     year : string (optional)
         The 4-digit year to pull the roster from, such as '2017'. If left
         blank, defaults to the most recent season.
+    slim : boolean (optional)
+        Set to True to return a limited subset of player information including
+        the name and player ID for each player as opposed to all of their
+        respective stats which greatly reduces the time to return a response if
+        just the names and IDs are desired. Defaults to False.
     """
-    def __init__(self, team, year=None):
+    def __init__(self, team, year=None, slim=False):
         self._team = team
-        self._players = []
+        self._slim = slim
+        if slim:
+            self._players = {}
+        else:
+            self._players = []
 
         self._find_players(year)
 
@@ -969,6 +978,27 @@ class Roster(object):
         name = re.sub(r'.*/players/', '', str(name_tag))
         return re.sub(r'\.htm.*', '', name)
 
+    def _get_name(self, player):
+        """
+        Parse the player's name.
+
+        Given a PyQuery object representing a single player on the team roster,
+        parse the player ID and return it as a string.
+
+        Parameters
+        ----------
+        player : PyQuery object
+            A PyQuery object representing the player information from the
+            roster table.
+
+        Returns
+        -------
+        string
+            Returns a string of the player's name.
+        """
+        name_tag = player('th[data-stat="player"] a')
+        return name_tag.text()
+
     def _find_players(self, year):
         """
         Find all player IDs for the requested team.
@@ -995,13 +1025,20 @@ class Roster(object):
             raise ValueError(output)
         for player in page('table#roster tbody tr').items():
             player_id = self._get_id(player)
-            player_instance = Player(player_id)
-            self._players.append(player_instance)
+            if self._slim:
+                name = self._get_name(player)
+                self._players[player_id] = name
+            else:
+                player_instance = Player(player_id)
+                self._players.append(player_instance)
 
     @property
     def players(self):
         """
         Returns a ``list`` of player instances for each player on the requested
-        team's roster.
+        team's roster if the ``slim`` property is False when calling the Roster
+        class. If the ``slim`` property is True, returns a ``dictionary`` where
+        each key is a string of the player's ID and each value is the player's
+        first and last name as listed on the roster page.
         """
         return self._players

--- a/sportsreference/nfl/roster.py
+++ b/sportsreference/nfl/roster.py
@@ -1521,10 +1521,19 @@ class Roster(object):
     year : string (optional)
         The 4-digit year to pull the roster from, such as '2017'. If left
         blank, defaults to the most recent season.
+    slim : boolean (optional)
+        Set to True to return a limited subset of player information including
+        the name and player ID for each player as opposed to all of their
+        respective stats which greatly reduces the time to return a response if
+        just the names and IDs are desired. Defaults to False.
     """
-    def __init__(self, team, year=None):
+    def __init__(self, team, year=None, slim=False):
         self._team = team
-        self._players = []
+        self._slim = slim
+        if slim:
+            self._players = {}
+        else:
+            self._players = []
 
         self._find_players(year)
 
@@ -1591,6 +1600,27 @@ class Roster(object):
         name = re.sub(r'.*/players/./', '', str(name_tag))
         return re.sub(r'\.htm.*', '', name)
 
+    def _get_name(self, player):
+        """
+        Parse the player's name.
+
+        Given a PyQuery object representing a single player on the team roster,
+        parse the player ID and return it as a string.
+
+        Parameters
+        ----------
+        player : PyQuery object
+            A PyQuery object representing the player information from the
+            roster table.
+
+        Returns
+        -------
+        string
+            Returns a string of the player's name.
+        """
+        name_tag = player('td[data-stat="player"] a')
+        return name_tag.text()
+
     def _find_players(self, year):
         """
         Find all player IDs for the requested team.
@@ -1617,13 +1647,20 @@ class Roster(object):
             raise ValueError(output)
         for player in page('table#games_played_team tbody tr').items():
             player_id = self._get_id(player)
-            player_instance = Player(player_id)
-            self._players.append(player_instance)
+            if self._slim:
+                name = self._get_name(player)
+                self._players[player_id] = name
+            else:
+                player_instance = Player(player_id)
+                self._players.append(player_instance)
 
     @property
     def players(self):
         """
         Returns a ``list`` of player instances for each player on the requested
-        team's roster.
+        team's roster if the ``slim`` property is False when calling the Roster
+        class. If the ``slim`` property is True, returns a ``dictionary`` where
+        each key is a string of the player's ID and each value is the player's
+        first and last name as listed on the roster page.
         """
         return self._players

--- a/sportsreference/nhl/roster.py
+++ b/sportsreference/nhl/roster.py
@@ -1283,10 +1283,19 @@ class Roster(object):
     year : string (optional)
         The 6-digit year to pull the roster from, such as '2017-18'. If left
         blank, defaults to the most recent season.
+    slim : boolean (optional)
+        Set to True to return a limited subset of player information including
+        the name and player ID for each player as opposed to all of their
+        respective stats which greatly reduces the time to return a response if
+        just the names and IDs are desired. Defaults to False.
     """
-    def __init__(self, team, year=None):
+    def __init__(self, team, year=None, slim=False):
         self._team = team
-        self._players = []
+        self._slim = slim
+        if slim:
+            self._players = {}
+        else:
+            self._players = []
 
         self._find_players(year)
 
@@ -1351,6 +1360,27 @@ class Roster(object):
         """
         return player('td[data-stat="player"]').attr('data-append-csv')
 
+    def _get_name(self, player):
+        """
+        Parse the player's name.
+
+        Given a PyQuery object representing a single player on the team roster,
+        parse the player ID and return it as a string.
+
+        Parameters
+        ----------
+        player : PyQuery object
+            A PyQuery object representing the player information from the
+            roster table.
+
+        Returns
+        -------
+        string
+            Returns a string of the player's name.
+        """
+        name_tag = player('td[data-stat="player"] a')
+        return name_tag.text()
+
     def _find_players(self, year):
         """
         Find all player IDs for the requested team.
@@ -1377,13 +1407,20 @@ class Roster(object):
             raise ValueError(output)
         for player in page('table#roster tbody tr').items():
             player_id = self._get_id(player)
-            player_instance = Player(player_id)
-            self._players.append(player_instance)
+            if self._slim:
+                name = self._get_name(player)
+                self._players[player_id] = name
+            else:
+                player_instance = Player(player_id)
+                self._players.append(player_instance)
 
     @property
     def players(self):
         """
         Returns a ``list`` of player instances for each player on the requested
-        team's roster.
+        team's roster if the ``slim`` property is False when calling the Roster
+        class. If the ``slim`` property is True, returns a ``dictionary`` where
+        each key is a string of the player's ID and each value is the player's
+        first and last name as listed on the roster page.
         """
         return self._players

--- a/tests/integration/roster/test_mlb_roster.py
+++ b/tests/integration/roster/test_mlb_roster.py
@@ -1185,3 +1185,17 @@ class TestMLBRoster:
             assert player.name in [u'José Altuve', 'Justin Verlander',
                                    'Charlie Morton']
         type(team)._abbreviation = None
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_roster_class_with_slim_parameter(self, *args, **kwargs):
+        flexmock(utils) \
+            .should_receive('_find_year_for_season') \
+            .and_return('2018')
+        roster = Roster('HOU', slim=True)
+
+        assert len(roster.players) == 3
+        assert roster.players == {
+            'altuvjo01': 'Jose Altuve',
+            'verlaju01': 'Justin Verlander',
+            'mortoch02': 'Charlie Morton'
+        }

--- a/tests/integration/roster/test_nba_roster.py
+++ b/tests/integration/roster/test_nba_roster.py
@@ -1211,3 +1211,18 @@ class TestNBARoster:
                                    'Ryan Anderson', 'Trevor Ariza']
 
         type(team)._abbreviation = None
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_roster_class_with_slim_parameter(self, *args, **kwargs):
+        flexmock(utils) \
+            .should_receive('_find_year_for_season') \
+            .and_return('2018')
+        roster = Roster('HOU', slim=True)
+
+        assert len(roster.players) == 4
+        assert roster.players == {
+            'hardeja01': 'James Harden',
+            'blackta01': 'Tarik Black',
+            'anderry01': 'Ryan Anderson',
+            'arizatr01': 'Trevor Ariza'
+        }

--- a/tests/integration/roster/test_ncaab_roster.py
+++ b/tests/integration/roster/test_ncaab_roster.py
@@ -379,3 +379,17 @@ class TestNCAABRoster:
             assert player.name in ['Carsen Edwards', 'Isaac Haas',
                                    'Vince Edwards']
         type(team)._abbreviation = None
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_roster_class_with_slim_parameter(self, *args, **kwargs):
+        flexmock(utils) \
+            .should_receive('_find_year_for_season') \
+            .and_return('2018')
+        roster = Roster('PURDUE', slim=True)
+
+        assert len(roster.players) == 3
+        assert roster.players == {
+            'carsen-edwards-1': 'Carsen Edwards',
+            'isaac-haas-1': 'Isaac Haas',
+            'vince-edwards-2': 'Vince Edwards'
+        }

--- a/tests/integration/roster/test_ncaaf_roster.py
+++ b/tests/integration/roster/test_ncaaf_roster.py
@@ -490,3 +490,16 @@ class TestNCAAFRoster:
         for player in team.roster.players:
             assert player.name in ['David Blough', 'Rondale Moore']
         type(team)._abbreviation = None
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_roster_class_with_slim_parameter(self, *args, **kwargs):
+        flexmock(utils) \
+            .should_receive('_find_year_for_season') \
+            .and_return('2018')
+        roster = Roster('PURDUE', slim=True)
+
+        assert len(roster.players) == 2
+        assert roster.players == {
+            'david-blough-1': 'David Blough',
+            'rondale-moore-1': 'Rondale Moore'
+        }

--- a/tests/integration/roster/test_nfl_roster.py
+++ b/tests/integration/roster/test_nfl_roster.py
@@ -1173,3 +1173,19 @@ class TestNFLRoster:
                                    'Tommylee Lewis', 'Wil Lutz',
                                    'Thomas Morstead']
         type(team)._abbreviation = None
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_roster_class_with_slim_parameter(self, *args, **kwargs):
+        flexmock(utils) \
+            .should_receive('_find_year_for_season') \
+            .and_return('2018')
+        roster = Roster('NOR', slim=True)
+
+        assert len(roster.players) == 5
+        assert roster.players == {
+            'BreeDr00': 'Drew Brees',
+            'DaviDe00': 'Demario Davis',
+            'LewiTo00': 'Tommylee Lewis',
+            'LutzWi00': 'Wil Lutz',
+            'MorsTh00': 'Thomas Morstead'
+        }

--- a/tests/integration/roster/test_nhl_roster.py
+++ b/tests/integration/roster/test_nhl_roster.py
@@ -686,3 +686,16 @@ class TestNHLRoster:
         for player in team.roster.players:
             assert player.name in ['Jimmy Howard', 'Henrik Zetterberg']
         type(team)._abbreviation = None
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_roster_class_with_slim_parameter(self, *args, **kwargs):
+        flexmock(utils) \
+            .should_receive('_find_year_for_season') \
+            .and_return('2018')
+        roster = Roster('DET', slim=True)
+
+        assert len(roster.players) == 2
+        assert roster.players == {
+            'howarja02': 'Jimmy Howard',
+            'zettehe01': 'Henrik Zetterberg'
+        }


### PR DESCRIPTION
A new slim parameter should be added to the Roster class if the desire is to just get the names and/or player ID's of each player on a team. This short-circuits the call to the Player class which eliminates the need for a 2-3 second instantiation and call to the individual player's stats page. This allows the names and IDs to be returned in a small fraction of the time compared to the standard request.

Fixes #26

Signed-Off-By: Robert Clark <robdclark@outlook.com>