### PR TITLE
Improve integration test performance

### DIFF
--- a/tests/integration/roster/test_nfl_roster.py
+++ b/tests/integration/roster/test_nfl_roster.py
@@ -43,8 +43,7 @@ def mock_pyquery(url):
 
 
 class TestNFLPlayer:
-    @mock.patch('requests.get', side_effect=mock_pyquery)
-    def setup_method(self, *args, **kwargs):
+    def setup_method(self):
         self.qb_results_career = {
             'adjusted_net_yards_per_attempt_index': 113,
             'adjusted_net_yards_per_pass_attempt': 6.98,
@@ -723,55 +722,64 @@ class TestNFLPlayer:
             'yards_returned_from_interception': None
         }
 
-        self.qb = Player('BreeDr00')
-        self.olb = Player('DaviDe00')
-        self.kicker = Player('LutzWi00')
-        self.punter = Player('MorsTh00')
-        self.receiver = Player('LewiTo00')
-
-    def test_nfl_qb_returns_requested_career_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_qb_returns_requested_career_stats(self, *args, **kwargs):
         # Request the career stats
-        player = self.qb('')
+        player = Player('BreeDr00')
+        player = player('')
 
         for attribute, value in self.qb_results_career.items():
             assert getattr(player, attribute) == value
 
-    def test_nfl_qb_returns_requested_player_season_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_qb_returns_requested_player_season_stats(self,
+                                                          *args,
+                                                          **kwargs):
         # Request the 2017 stats
-        player = self.qb('2017')
+        player = Player('BreeDr00')
+        player = player('2017')
 
         for attribute, value in self.qb_results_2017.items():
             assert getattr(player, attribute) == value
 
-    def test_nfl_olb_returns_requested_career_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_olb_returns_requested_career_stats(self, *args, **kwargs):
         # Request the career stats
-        player = self.olb('')
+        player = Player('DaviDe00')
+        player = player('')
 
         for attribute, value in self.olb_results_career.items():
             assert getattr(player, attribute) == value
 
-    def test_nfl_kicker_returns_requested_career_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_kicker_returns_requested_career_stats(self, *args, **kwargs):
         # Request the career stats
-        player = self.kicker('')
+        player = Player('LutzWi00')
+        player = player('')
 
         for attribute, value in self.kicker_results_career.items():
             assert getattr(player, attribute) == value
 
-    def test_nfl_punter_returns_requested_career_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_punter_returns_requested_career_stats(self, *args, **kwargs):
         # Request the career stats
-        player = self.punter('')
+        player = Player('MorsTh00')
+        player = player('')
 
         for attribute, value in self.punter_results_career.items():
             assert getattr(player, attribute) == value
 
-    def test_nfl_olb_receiver_requested_career_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_olb_receiver_requested_career_stats(self, *args, **kwargs):
         # Request the career stats
-        player = self.receiver('')
+        player = Player('LewiTo00')
+        player = player('')
 
         for attribute, value in self.receiver_results_career.items():
             assert getattr(player, attribute) == value
 
-    def test_dataframe_returns_dataframe(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_dataframe_returns_dataframe(self, *args, **kwargs):
         dataframe = [
             {'adjusted_net_yards_per_attempt_index': 116,
              'adjusted_net_yards_per_pass_attempt': 7.71,
@@ -1107,7 +1115,8 @@ class TestNFLPlayer:
         indices = ['2017', '2018', 'Career']
 
         df = pd.DataFrame(dataframe, index=indices)
-        player = self.qb('')
+        player = Player('BreeDr00')
+        player = player('')
 
         # Pandas doesn't natively allow comparisons of DataFrames.
         # Concatenating the two DataFrames (the one generated during the test
@@ -1118,20 +1127,29 @@ class TestNFLPlayer:
         frames = [df, player.dataframe]
         df1 = pd.concat(frames).drop_duplicates(keep=False)
 
-    def test_nfl_fake_404_page_returns_none_with_no_errors(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_fake_404_page_returns_none_with_no_errors(self,
+                                                           *args,
+                                                           **kwargs):
         player = Player('404')
 
         assert player.name is None
         assert player.dataframe is None
 
-    def test_nfl_fake_404_page_returns_none_for_different_season(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_fake_404_page_returns_none_for_different_season(self,
+                                                                 *args,
+                                                                 **kwargs):
         player = Player('404')
         player = player('2017')
 
         assert player.name is None
         assert player.dataframe is None
 
-    def test_nfl_player_with_no_career_stats_handled_properly(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nfl_player_with_no_career_stats_handled_properly(self,
+                                                              *args,
+                                                              **kwargs):
         player = Player('HatfDo00')
 
         assert player.name == 'Dominique Hatfield'

--- a/tests/integration/roster/test_nhl_roster.py
+++ b/tests/integration/roster/test_nhl_roster.py
@@ -33,8 +33,7 @@ def mock_pyquery(url):
 
 
 class TestNHLPlayer:
-    @mock.patch('requests.get', side_effect=mock_pyquery)
-    def setup_method(self, *args, **kwargs):
+    def setup_method(self):
         self.skater_results_career = {
             'adjusted_assists': 692,
             'adjusted_goals': 377,
@@ -411,38 +410,44 @@ class TestNHLPlayer:
             'wins': 22
         }
 
-        self.skater = Player('zettehe01')
-        self.goalie = Player('howarja02')
-
-    def test_nhl_skater_returns_requested_career_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nhl_skater_returns_requested_career_stats(self, *args, **kwargs):
         # Request the career stats
-        player = self.skater('')
+        player = Player('zettehe01')
+        player = player('')
 
         for attribute, value in self.skater_results_career.items():
             assert getattr(player, attribute) == value
 
-    def test_nhl_skater_returns_player_season_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nhl_skater_returns_player_season_stats(self, *args, **kwargs):
         # Request the 2017 stats
-        player = self.skater('2017-18')
+        player = Player('zettehe01')
+        player = player('2017-18')
 
         for attribute, value in self.skater_results_2017.items():
             assert getattr(player, attribute) == value
 
-    def test_nhl_goalie_returns_requested_career_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nhl_goalie_returns_requested_career_stats(self, *args, **kwargs):
         # Request the career stats
-        player = self.goalie('')
+        player = Player('howarja02')
+        player = player('')
 
         for attribute, value in self.goalie_results_career.items():
             assert getattr(player, attribute) == value
 
-    def test_nhl_goalie_returns_player_season_stats(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nhl_goalie_returns_player_season_stats(self, *args, **kwargs):
         # Request the 2017 stats
-        player = self.goalie('2017-18')
+        player = Player('howarja02')
+        player = player('2017-18')
 
         for attribute, value in self.goalie_results_2017.items():
             assert getattr(player, attribute) == value
 
-    def test_dataframe_returns_dataframe(self):
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_dataframe_returns_dataframe(self, *args, **kwargs):
         dataframe = [
             {'adjusted_assists': 46,
              'adjusted_goals': 11,
@@ -630,7 +635,7 @@ class TestNHLPlayer:
         indices = ['2017', 'Career']
 
         df = pd.DataFrame(dataframe, index=indices)
-        player = self.skater('')
+        player = Player('zettehe01')
 
         # Pandas doesn't natively allow comparisons of DataFrames.
         # Concatenating the two DataFrames (the one generated during the test

--- a/tests/integration/schedule/test_mlb_schedule.py
+++ b/tests/integration/schedule/test_mlb_schedule.py
@@ -71,6 +71,9 @@ class TestMLBSchedule:
         flexmock(Boxscore) \
             .should_receive('_parse_game_data') \
             .and_return(None)
+        flexmock(Boxscore) \
+            .should_receive('dataframe') \
+            .and_return(pd.DataFrame([{'key': 'value'}]))
         flexmock(utils) \
             .should_receive('_todays_date') \
             .and_return(MockDateTime(YEAR, MONTH))
@@ -138,10 +141,6 @@ class TestMLBSchedule:
     def test_mlb_schedule_dataframe_extended_returns_dataframe(self):
         df = pd.DataFrame([{'key': 'value'}])
 
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule[1].dataframe_extended
 
         frames = [df, result]
@@ -150,20 +149,12 @@ class TestMLBSchedule:
         assert df1.empty
 
     def test_mlb_schedule_all_dataframe_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule.dataframe.drop_duplicates(keep=False)
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE
         assert set(result.columns.values) == set(self.results.keys())
 
     def test_mlb_schedule_all_dataframe_extended_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule.dataframe_extended
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE

--- a/tests/integration/schedule/test_nba_schedule.py
+++ b/tests/integration/schedule/test_nba_schedule.py
@@ -93,6 +93,9 @@ class TestNBASchedule:
         flexmock(Boxscore) \
             .should_receive('_parse_game_data') \
             .and_return(None)
+        flexmock(Boxscore) \
+            .should_receive('dataframe') \
+            .and_return(pd.DataFrame([{'key': 'value'}]))
         flexmock(utils) \
             .should_receive('_todays_date') \
             .and_return(MockDateTime(YEAR, MONTH))
@@ -132,10 +135,6 @@ class TestNBASchedule:
     def test_nba_schedule_dataframe_extended_returns_dataframe(self):
         df = pd.DataFrame([{'key': 'value'}])
 
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule[1].dataframe_extended
 
         frames = [df, result]
@@ -144,19 +143,12 @@ class TestNBASchedule:
         assert df1.empty
 
     def test_nba_schedule_all_dataframe_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
         result = self.schedule.dataframe.drop_duplicates(keep=False)
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE
         assert set(result.columns.values) == set(self.results.keys())
 
     def test_nba_schedule_all_dataframe_extended_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule.dataframe_extended
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE

--- a/tests/integration/schedule/test_ncaab_schedule.py
+++ b/tests/integration/schedule/test_ncaab_schedule.py
@@ -69,6 +69,12 @@ class TestNCAABSchedule:
         flexmock(utils) \
             .should_receive('_todays_date') \
             .and_return(MockDateTime(YEAR, MONTH))
+        flexmock(Boxscore) \
+            .should_receive('_parse_game_data') \
+            .and_return(None)
+        flexmock(Boxscore) \
+            .should_receive('dataframe') \
+            .and_return(pd.DataFrame([{'key': 'value'}]))
 
         self.schedule = Schedule('KANSAS')
 
@@ -105,10 +111,6 @@ class TestNCAABSchedule:
     def test_ncaab_schedule_dataframe_extended_returns_dataframe(self):
         df = pd.DataFrame([{'key': 'value'}])
 
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule[1].dataframe_extended
 
         frames = [df, result]
@@ -117,13 +119,6 @@ class TestNCAABSchedule:
         assert df1.empty
 
     def test_ncaab_schedule_all_dataframe_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('_parse_game_data') \
-            .and_return(None)
-
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
 
         result = self.schedule.dataframe.drop_duplicates(keep=False)
 
@@ -131,14 +126,6 @@ class TestNCAABSchedule:
         assert set(result.columns.values) == set(self.results.keys())
 
     def test_ncaab_schedule_all_dataframe_extended_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('_parse_game_data') \
-            .and_return(None)
-
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule.dataframe_extended
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE

--- a/tests/integration/schedule/test_ncaaf_schedule.py
+++ b/tests/integration/schedule/test_ncaaf_schedule.py
@@ -68,6 +68,12 @@ class TestNCAAFSchedule:
         flexmock(utils) \
             .should_receive('_todays_date') \
             .and_return(MockDateTime(YEAR, MONTH))
+        flexmock(Boxscore) \
+            .should_receive('_parse_game_data') \
+            .and_return(None)
+        flexmock(Boxscore) \
+            .should_receive('dataframe') \
+            .and_return(pd.DataFrame([{'key': 'value'}]))
 
         self.schedule = Schedule('MICHIGAN')
 
@@ -104,10 +110,6 @@ class TestNCAAFSchedule:
     def test_ncaaf_schedule_dataframe_extended_returns_dataframe(self):
         df = pd.DataFrame([{'key': 'value'}])
 
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule[1].dataframe_extended
 
         frames = [df, result]
@@ -116,19 +118,12 @@ class TestNCAAFSchedule:
         assert df1.empty
 
     def test_ncaaf_schedule_all_dataframe_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
         result = self.schedule.dataframe.drop_duplicates(keep=False)
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE
         assert set(result.columns.values) == set(self.results.keys())
 
     def test_ncaaf_schedule_all_dataframe_extended_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule.dataframe_extended
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE

--- a/tests/integration/schedule/test_nfl_schedule.py
+++ b/tests/integration/schedule/test_nfl_schedule.py
@@ -90,6 +90,12 @@ class TestNFLSchedule:
         flexmock(utils) \
             .should_receive('_todays_date') \
             .and_return(MockDateTime(YEAR, MONTH))
+        flexmock(Boxscore) \
+            .should_receive('_parse_game_data') \
+            .and_return(None)
+        flexmock(Boxscore) \
+            .should_receive('dataframe') \
+            .and_return(pd.DataFrame([{'key': 'value'}]))
 
         self.schedule = Schedule('NWE')
 
@@ -126,10 +132,6 @@ class TestNFLSchedule:
     def test_nfl_schedule_dataframe_extended_returns_dataframe(self):
         df = pd.DataFrame([{'key': 'value'}])
 
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule[1].dataframe_extended
 
         frames = [df, result]
@@ -138,19 +140,12 @@ class TestNFLSchedule:
         assert df1.empty
 
     def test_nfl_schedule_all_dataframe_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
         result = self.schedule.dataframe.drop_duplicates(keep=False)
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE
         assert set(result.columns.values) == set(self.results.keys())
 
     def test_nfl_schedule_all_dataframe_extended_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule.dataframe_extended
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE

--- a/tests/integration/schedule/test_nhl_schedule.py
+++ b/tests/integration/schedule/test_nhl_schedule.py
@@ -82,6 +82,12 @@ class TestNHLSchedule:
         flexmock(utils) \
             .should_receive('_todays_date') \
             .and_return(MockDateTime(YEAR, MONTH))
+        flexmock(Boxscore) \
+            .should_receive('_parse_game_data') \
+            .and_return(None)
+        flexmock(Boxscore) \
+            .should_receive('dataframe') \
+            .and_return(pd.DataFrame([{'key': 'value'}]))
 
         self.schedule = Schedule('NYR')
 
@@ -118,10 +124,6 @@ class TestNHLSchedule:
     def test_nhl_schedule_dataframe_extended_returns_dataframe(self):
         df = pd.DataFrame([{'key': 'value'}])
 
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule[1].dataframe_extended
 
         frames = [df, result]
@@ -130,19 +132,12 @@ class TestNHLSchedule:
         assert df1.empty
 
     def test_nhl_schedule_all_dataframe_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
         result = self.schedule.dataframe.drop_duplicates(keep=False)
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE
         assert set(result.columns.values) == set(self.results.keys())
 
     def test_nhl_schedule_all_dataframe_extended_returns_dataframe(self):
-        flexmock(Boxscore) \
-            .should_receive('dataframe') \
-            .and_return(pd.DataFrame([{'key': 'value'}]))
-
         result = self.schedule.dataframe_extended
 
         assert len(result) == NUM_GAMES_IN_SCHEDULE


### PR DESCRIPTION
Many of the integration tests were getting stuck while either trying to pull from the external network (which should be avoided) or re-pulling information that was unnecessary for a given test. This would cause some tests to takeas long as two minutes while trying to pull all of the desired information when they should be taking a couple seconds or less. The new updates test all of the same code, but go about it in a smarter
way to reduce the testing time by 66%.

Signed-Off-By: Robert Clark <robdclark@outlook.com>