### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ jobs:
       python: 2.7
       dist: trusty
     - stage: test
-      python: 3.4
-      dist: trusty
-    - stage: test
       python: 3.5
       dist: trusty
     - stage: test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flexmock>=0.10.2
 mock>=2.0.0
-pandas>=0.21.0
+pandas>=0.24.1
 pycodestyle>=2.4.0
 pyquery>=1.4.0
 pytest-cov>=2.5.1

--- a/setup.py
+++ b/setup.py
@@ -16,16 +16,15 @@ setup(
     license='MIT',
     url='https://github.com/roclark/sportsreference',
     packages=find_packages(),
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
     keywords='stats sports api sportsreference machine learning',
     install_requires=[
-        "pandas >= 0.21.0",
+        "pandas >= 0.24.1",
         "pyquery >= 1.4.0",
         "requests >= 2.18.4"
     ],
     classifiers=(
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
With Python 3.4 officially reaching end-of-life on March 16, 2019, support should be dropped from `sportsreference` to encourage users to transition to a newer version of Python.

Signed-Off-By: Robert Clark <robdclark@outlook.com>