### PR TITLE
Fix issue pulling historical NCAAB fields

### DIFF
--- a/sportsreference/ncaab/teams.py
+++ b/sportsreference/ncaab/teams.py
@@ -538,7 +538,10 @@ class Team(object):
         Returns an ``int`` of the total number of defensive rebounds during the
         season.
         """
-        return self.total_rebounds - self.offensive_rebounds
+        try:
+            return self.total_rebounds - self.offensive_rebounds
+        except TypeError:
+            return None
 
     @int_property_decorator
     def total_rebounds(self):
@@ -702,7 +705,10 @@ class Team(object):
         Returns an ``int`` of the total number of defensive rebounds during the
         season by opponents.
         """
-        return self.opp_total_rebounds - self.opp_offensive_rebounds
+        try:
+            return self.opp_total_rebounds - self.opp_offensive_rebounds
+        except TypeError:
+            return None
 
     @int_property_decorator
     def opp_total_rebounds(self):
@@ -776,7 +782,10 @@ class Team(object):
         opponent's offensive) rating. Positive values indicate teams that score
         more points than they allow per 100 possessions.
         """
-        return self.offensive_rating - self.opp_offensive_rating
+        try:
+            return self.offensive_rating - self.opp_offensive_rating
+        except TypeError:
+            return None
 
     @float_property_decorator
     def free_throw_attempt_rate(self):

--- a/tests/unit/test_ncaab_teams.py
+++ b/tests/unit/test_ncaab_teams.py
@@ -50,3 +50,51 @@ class TestNCAABTeams:
         result = team.opp_two_point_field_goal_percentage
 
         assert result == 0.0
+
+    def test_defensive_rebounds_with_missing_data_returns_default(self):
+        flexmock(Team) \
+            .should_receive('_parse_team_data') \
+            .and_return(None)
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+
+        team = Team(None, 1)
+        mock_offensive_rebounds = PropertyMock(return_value=None)
+        type(team).offensive_rebounds = mock_offensive_rebounds
+
+        result = team.defensive_rebounds
+
+        assert not result
+
+    def test_opp_defensive_rebounds_with_missing_data_returns_default(self):
+        flexmock(Team) \
+            .should_receive('_parse_team_data') \
+            .and_return(None)
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+
+        team = Team(None, 1)
+        mock_offensive_rebounds = PropertyMock(return_value=None)
+        type(team).opp_offensive_rebounds = mock_offensive_rebounds
+
+        result = team.opp_defensive_rebounds
+
+        assert not result
+
+    def test_net_rating_with_missing_data_returns_default(self):
+        flexmock(Team) \
+            .should_receive('_parse_team_data') \
+            .and_return(None)
+        flexmock(Schedule) \
+            .should_receive('_pull_schedule') \
+            .and_return(None)
+
+        team = Team(None, 1)
+        mock_offensive_rating = PropertyMock(return_value=None)
+        type(team).offensive_rating = mock_offensive_rating
+
+        result = team.net_rating
+
+        assert not result


### PR DESCRIPTION
Prior to the 2009 season, sports-reference.com contained less data for each NCAAB team. Any fields that were missing that require mathematical operations (such as the subtraction in `defensive_rebounds`, `opp_defensive_rebounds`, and `net_rating`), if at least one of the fields is empty, the command will throw an error. To combat this behavior, we need to pre-emptively catch any arithmetic errors and return a default value.

Fixes #68 

Signed-Off-By: Robert Clark <robdclark@outlook.com>