### PR TITLE
Fix issue pulling NBA playoff games

### DIFF
--- a/sportsreference/nba/schedule.py
+++ b/sportsreference/nba/schedule.py
@@ -398,7 +398,7 @@ class Schedule(object):
         doc = pq(SCHEDULE_URL % (abbreviation, year))
         schedule = utils._get_stats_table(doc, 'table#games')
         self._add_games_to_schedule(schedule)
-        if 'games_playoffs' in str(doc):
+        if 'id="games_playoffs"' in str(doc):
             playoffs = utils._get_stats_table(doc, 'table#games_playoffs')
             self._add_games_to_schedule(playoffs)
 


### PR DESCRIPTION
Iterating through an NBA team's schedule right before the playoffs begin can throw an error for participating teams as basketball-reference.com uses a link similar to one being used to identify playoff games in sportsreference. By directly checking for the ID tag used in the playoff table, we can cleanly pull the NBA table if applicable.

Fixes #72

Signed-Off-By: Robert Clark <robdclark@outlook.com>