### PR TITLE
Fix issue pulling NHL rosters

### DIFF
--- a/sportsreference/nhl/roster.py
+++ b/sportsreference/nhl/roster.py
@@ -1137,7 +1137,7 @@ class Roster(object):
             Returns a string of the team's season page for the requested team
             and year.
         """
-        return ROSTER_URL % (self._team.lower(), year)
+        return ROSTER_URL % (self._team.upper(), year)
 
     def _get_id(self, player):
         """


### PR DESCRIPTION
The NHL team rosters were throwing errors for certain teams when the website only uses uppercase team abbreviations, like with the Vegas Golen Knights. Forcing abbreviations to be uppercase resolves this issue.

Fixes #99

Signed-Off-By: Robert Clark <robdclark@outlook.com>