### PR TITLE
Add playoff indicator to NBA schedules

### DIFF
--- a/tests/integration/schedule/test_nba_schedule.py
+++ b/tests/integration/schedule/test_nba_schedule.py
@@ -70,6 +70,7 @@ class TestNBASchedule:
             'opponent_abbr': 'NOP',
             'opponent_name': 'New Orleans Pelicans',
             'result': WIN,
+            'playoffs': False,
             'points_scored': 122,
             'points_allowed': 114,
             'wins': 1,


### PR DESCRIPTION
The NBA playoff schedules should include a binary indicator which can be used to identify if a game was played during the playoffs or the regular season.

Fixes #78

Signed-Off-By: Robert Clark <robdclark@outlook.com>