### PR TITLE
Fix issue getting home names in NCAAB playoffs

### DIFF
--- a/sportsreference/ncaab/boxscore.py
+++ b/sportsreference/ncaab/boxscore.py
@@ -1767,7 +1767,8 @@ class Boxscores:
         """
         # Grab the first <td...> tag for each <tr> row in the boxscore,
         # representing the name for each participating team.
-        links = [g('td:first') for g in game('tr').items()]
+        links = [g('td:first') for g in game('tr').items()
+                 if 'class="desc"' not in str(g('td:first'))]
         # The away team is the first link in the boxscore
         away = links[0]
         # The home team is the last (3rd) link in the boxscore


### PR DESCRIPTION
For any NCAAB post-season match, the Boxscores class would fail to pull the correct home team's name as it falsely claimed the final table descriptor as the home team's name, when it actually is dedicated to information on the specific playoff game, such as 'Big Ten Conf Tournament - Final'.

Fixes #77

Signed-Off-By: Robert Clark <robdclark@outlook.com>