### PR TITLE
Force UTF-8 encoding for opening test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ include/*
 lib/*
 man/*
 pip-selfcheck.json
+env/*

--- a/tests/integration/boxscore/test_mlb_boxscore.py
+++ b/tests/integration/boxscore/test_mlb_boxscore.py
@@ -17,7 +17,7 @@ BOXSCORE = 'BOS/BOS201806070'
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'mlb', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/boxscore/test_nba_boxscore.py
+++ b/tests/integration/boxscore/test_nba_boxscore.py
@@ -17,7 +17,7 @@ BOXSCORE = '201710310LAL'
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nba', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/boxscore/test_ncaab_boxscore.py
+++ b/tests/integration/boxscore/test_ncaab_boxscore.py
@@ -17,7 +17,7 @@ BOXSCORE = '2017-11-24-21-purdue'
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'ncaab', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/boxscore/test_ncaaf_boxscore.py
+++ b/tests/integration/boxscore/test_ncaaf_boxscore.py
@@ -17,7 +17,7 @@ BOXSCORE = '2018-01-08-georgia'
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'ncaaf', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/boxscore/test_nfl_boxscore.py
+++ b/tests/integration/boxscore/test_nfl_boxscore.py
@@ -17,7 +17,7 @@ BOXSCORE = '201802040nwe'
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nfl', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/boxscore/test_nhl_boxscore.py
+++ b/tests/integration/boxscore/test_nhl_boxscore.py
@@ -17,7 +17,7 @@ BOXSCORE = '201806070VEG'
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nhl', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/conferences/test_ncaab_conferences.py
+++ b/tests/integration/conferences/test_ncaab_conferences.py
@@ -11,7 +11,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = join(dirname(__file__), 'ncaab', filename)
-    return open(filepath, 'r').read()
+    return open(filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/conferences/test_ncaaf_conferences.py
+++ b/tests/integration/conferences/test_ncaaf_conferences.py
@@ -11,7 +11,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = join(dirname(__file__), 'ncaaf', filename)
-    return open(filepath, 'r').read()
+    return open(filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/rankings/test_ncaab_rankings.py
+++ b/tests/integration/rankings/test_ncaab_rankings.py
@@ -11,7 +11,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = join(dirname(__file__), 'ncaab', filename)
-    return open(filepath, 'r').read()
+    return open(filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/rankings/test_ncaaf_rankings.py
+++ b/tests/integration/rankings/test_ncaaf_rankings.py
@@ -11,7 +11,7 @@ YEAR = 2017
 
 def read_file(filename):
     filepath = join(dirname(__file__), 'ncaaf', filename)
-    return open(filepath, 'r').read()
+    return open(filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/roster/test_mlb_roster.py
+++ b/tests/integration/roster/test_mlb_roster.py
@@ -14,7 +14,7 @@ YEAR = 2017
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'mlb', filename)
-    return open('%s.shtml' % filepath, 'r').read()
+    return open('%s.shtml' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/roster/test_nba_roster.py
+++ b/tests/integration/roster/test_nba_roster.py
@@ -14,7 +14,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nba', filename)
-    return open('%s.html' % filepath, 'r').read()
+    return open('%s.html' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/roster/test_ncaab_roster.py
+++ b/tests/integration/roster/test_ncaab_roster.py
@@ -14,7 +14,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'ncaab', filename)
-    return open('%s.html' % filepath, 'r').read()
+    return open('%s.html' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/roster/test_ncaaf_roster.py
+++ b/tests/integration/roster/test_ncaaf_roster.py
@@ -13,7 +13,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'ncaaf', filename)
-    return open('%s.html' % filepath, 'r').read()
+    return open('%s.html' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/roster/test_nfl_roster.py
+++ b/tests/integration/roster/test_nfl_roster.py
@@ -13,7 +13,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nfl', filename)
-    return open('%s.htm' % filepath, 'r').read()
+    return open('%s.htm' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/roster/test_nhl_roster.py
+++ b/tests/integration/roster/test_nhl_roster.py
@@ -13,7 +13,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nhl', filename)
-    return open('%s.html' % filepath, 'r').read()
+    return open('%s.html' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/schedule/test_mlb_schedule.py
+++ b/tests/integration/schedule/test_mlb_schedule.py
@@ -19,7 +19,7 @@ NUM_GAMES_IN_SCHEDULE = 162
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'mlb', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/schedule/test_nba_schedule.py
+++ b/tests/integration/schedule/test_nba_schedule.py
@@ -19,7 +19,7 @@ NUM_GAMES_IN_SCHEDULE = 99
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nba', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/schedule/test_ncaab_schedule.py
+++ b/tests/integration/schedule/test_ncaab_schedule.py
@@ -19,7 +19,7 @@ NUM_GAMES_IN_SCHEDULE = 39
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'ncaab', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/schedule/test_ncaaf_schedule.py
+++ b/tests/integration/schedule/test_ncaaf_schedule.py
@@ -19,7 +19,7 @@ NUM_GAMES_IN_SCHEDULE = 13
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'ncaaf', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/schedule/test_nfl_schedule.py
+++ b/tests/integration/schedule/test_nfl_schedule.py
@@ -19,7 +19,7 @@ NUM_GAMES_IN_SCHEDULE = 19
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nfl', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/schedule/test_nhl_schedule.py
+++ b/tests/integration/schedule/test_nhl_schedule.py
@@ -19,7 +19,7 @@ NUM_GAMES_IN_SCHEDULE = 82
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nhl', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/teams/test_mlb_integration.py
+++ b/tests/integration/teams/test_mlb_integration.py
@@ -14,7 +14,7 @@ YEAR = 2017
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'mlb_stats', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/teams/test_nba_integration.py
+++ b/tests/integration/teams/test_nba_integration.py
@@ -14,7 +14,7 @@ YEAR = 2017
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nba_stats', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_request(url):

--- a/tests/integration/teams/test_ncaab_integration.py
+++ b/tests/integration/teams/test_ncaab_integration.py
@@ -18,7 +18,7 @@ YEAR = 2018
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'ncaab_stats', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/teams/test_ncaaf_integration.py
+++ b/tests/integration/teams/test_ncaaf_integration.py
@@ -16,7 +16,7 @@ YEAR = 2017
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'ncaaf_stats', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/teams/test_nfl_integration.py
+++ b/tests/integration/teams/test_nfl_integration.py
@@ -14,7 +14,7 @@ YEAR = 2017
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nfl_stats', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):

--- a/tests/integration/teams/test_nhl_integration.py
+++ b/tests/integration/teams/test_nhl_integration.py
@@ -14,7 +14,7 @@ YEAR = 2017
 
 def read_file(filename):
     filepath = os.path.join(os.path.dirname(__file__), 'nhl_stats', filename)
-    return open('%s' % filepath, 'r').read()
+    return open('%s' % filepath, 'r', encoding='utf8').read()
 
 
 def mock_pyquery(url):


### PR DESCRIPTION
In some cases (such as running tests in Visual Studio Code), the "open" function in Python uses the incorrect file encoding format which can cause errors. To combat this, the encoding format should be explicitly stated.

Signed-Off-By: Robert Clark <robdclark@outlook.com>