### PR TITLE
Fix issue pulling weight of older NCAAF players

### DIFF
--- a/sportsreference/ncaaf/roster.py
+++ b/sportsreference/ncaaf/roster.py
@@ -486,7 +486,10 @@ class Player(AbstractPlayer):
         """
         Returns an ``int`` of the player's weight in pounds.
         """
-        return int(self._weight.replace('lb', ''))
+        try:
+            return int(self._weight.replace('lb', ''))
+        except AttributeError:
+            return None
 
     @property
     def year(self):

--- a/tests/unit/test_ncaaf_roster.py
+++ b/tests/unit/test_ncaaf_roster.py
@@ -38,3 +38,13 @@ class TestNCAAFPlayer:
         result = player._retrieve_html_page()
 
         assert result is None
+
+    @patch('requests.get', side_effect=mock_pyquery)
+    def test_missing_weight_returns_none(self, *args, **kwargs):
+        mock_weight = PropertyMock(return_value=None)
+        player = Player(None)
+        type(player)._player_id = mock_weight
+
+        result = player.weight
+
+        assert result is None


### PR DESCRIPTION
While attempting to pull player information for players from several seasons ago (tested on 2000 and earlier), sports-reference.com doesn't always contain the player's weight. In this case, their weight will still be set as `None`, causing an `AttributeError` to be thrown while attempting to replace the contents of what it expects to be a string. If this situation occurs, the weight should stay as `None` for the end-user to decide how they want to handle the omission.

Fixes #141

Signed-Off-By: Robert Clark <robdclark@outlook.com>