### PR TITLE
Fix issue pulling NCAAF games without time

### DIFF
--- a/sportsreference/ncaaf/schedule.py
+++ b/sportsreference/ncaaf/schedule.py
@@ -190,7 +190,7 @@ class Game:
         was played. If the game doesn't include a time, the default value of
         '00:00' will be used.
         """
-        if self._time == '':
+        if self._time == '' or not self._time:
             return datetime.strptime(self._date, '%b %d, %Y')
         date_string = '%s %s' % (self._date, self._time)
         return datetime.strptime(date_string, '%b %d, %Y %I:%M %p')


### PR DESCRIPTION
In the seasons prior to 2013, sports-reference.com does not include a time field in the NCAAF game's information page. This causes the time property to be set to `None`, which fails while attempting to parse a `DateTime` between the date and time properties. This behavior can be circumvented by only creating a DateTime of the date as opposed to the date and time when time is `None`.

Fixes #138

Signed-Off-By: Robert Clark <robdclark@outlook.com>