### PR TITLE
Support coverage.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ sudo: false
 
 install:
   - pip install -r requirements.txt
+  - pip install codecov
 
 script:
   - py.test --cov=sportsreference --cov-report term-missing tests/
   - pycodestyle sportsreference/ tests/
+
+after_success:
+  - codecov
 
 jobs:
   include:


### PR DESCRIPTION
Code coverage should be tracked in the project to ensure testing coverage doesn't accidently go down with new updates. All new code that is published in the repository should contain tests - coverage.io will help to ensure sportsreference keeps its high test coverage.

Signed-Off-By: Robert Clark <robdclark@outlook.com>