### PR TITLE
Update Houston Texan's abbreviation

### DIFF
--- a/docs/nfl.rst
+++ b/docs/nfl.rst
@@ -149,7 +149,7 @@ information on the game metrics.
 
     from sportsreference.nfl.schedule import Schedule
 
-    houston_schedule = Schedule('HOU')
+    houston_schedule = Schedule('HTX')
     for game in houston_schedule:
         print(game.date)  # Prints the date the game was played
         print(game.result)  # Prints whether the team won or lost

--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -1242,7 +1242,7 @@ class Boxscores:
                                  (`str`),
                     'away_name': Name of the away team, such as 'Houston
                                  Texans' (`str`),
-                    'away_abbr': Abbreviation for the away team, such as 'HOU'
+                    'away_abbr': Abbreviation for the away team, such as 'HTX'
                                  (`str`),
                     'boxscore': String representing the boxscore URI, such as
                                 'SLN/SLN201807280' (`str`),
@@ -1253,7 +1253,7 @@ class Boxscores:
                     'losing_name': Full name of the losing team, such as
                                    'Houston Texans' (`str`),
                     'losing_abbr': Abbreviation for the losing team, such as
-                                   'HOU' (`str`),
+                                   'HTX' (`str`),
                     'home_score': Integer score for the home team (`int`),
                     'away_score': Integer score for the away team (`int`)
                 },


### PR DESCRIPTION
The team at sports-reference.com changed the abbreviation used for the Houston Texans in all of the NFL's pages from 'HOU' to 'HTX'. When attempting to retrieve data from the Texans using 'HOU', an error will be thrown indicating that there is no data to collect. To reflect this change, all of the documentation that mentioned 'HOU' in the NFL modules should be updated to 'HTX'.

Fixes #160

Signed-Off-By: Robert Clark <robdclark@outlook.com>