### PR TITLE
Add support for additional NBA nationalities

### DIFF
--- a/sportsreference/nba/constants.py
+++ b/sportsreference/nba/constants.py
@@ -292,6 +292,7 @@ PLAYER_SCHEME = {
 }
 
 NATIONALITY = {
+    'ao': 'Angola',
     'ag': 'Antigua and Barbuda',
     'ar': 'Argentina',
     'au': 'Australia',
@@ -324,6 +325,7 @@ NATIONALITY = {
     'gh': 'Ghana',
     'gr': 'Greece',
     'gp': 'Guadeloupe',
+    'gn': 'Guinea',
     'gy': 'Guyana',
     'ht': 'Haiti',
     'hu': 'Hungary',


### PR DESCRIPTION
After the summer 2019 NBA draft and transfer window, a couple of new players became the first ever players to represent their country in the NBA. As a result, support for their countries was not included yet, preventing sportsreference from pulling stats from these players without throwing errors. With support added, all NBA teams can now be pulled with every roster able to be analyzed.

Fixes #167

Signed-Off-By: Robert Clark <robdclark@outlook.com>