### PR TITLE
Fix issue retrieving data from empty pages

### DIFF
--- a/sportsreference/mlb/schedule.py
+++ b/sportsreference/mlb/schedule.py
@@ -472,6 +472,9 @@ class Schedule:
                 year = str(int(year) - 1)
         doc = pq(SCHEDULE_URL % (abbreviation, year))
         schedule = utils._get_stats_table(doc, 'table#team_schedule')
+        if not schedule:
+            utils._no_data_found()
+            return
 
         for item in schedule:
             if 'class="thead"' in str(item):

--- a/sportsreference/mlb/teams.py
+++ b/sportsreference/mlb/teams.py
@@ -1295,6 +1295,9 @@ class Teams:
         div_prefix = 'div#all_teams_standard_%s'
         batting_stats = utils._get_stats_table(doc, div_prefix % 'batting')
         pitching_stats = utils._get_stats_table(doc, div_prefix % 'pitching')
+        if not standings and not batting_stats and not pitching_stats:
+            utils._no_data_found()
+            return
         for stats_list in [standings, batting_stats, pitching_stats]:
             team_data_dict = self._add_stats_data(stats_list, team_data_dict)
 

--- a/sportsreference/nba/schedule.py
+++ b/sportsreference/nba/schedule.py
@@ -417,6 +417,9 @@ class Schedule:
                 year = str(int(year) - 1)
         doc = pq(SCHEDULE_URL % (abbreviation, year))
         schedule = utils._get_stats_table(doc, 'table#games')
+        if not schedule:
+            utils._no_data_found()
+            return
         self._add_games_to_schedule(schedule)
         if 'id="games_playoffs"' in str(doc):
             playoffs = utils._get_stats_table(doc, 'table#games_playoffs')

--- a/sportsreference/nba/teams.py
+++ b/sportsreference/nba/teams.py
@@ -719,6 +719,9 @@ class Teams:
         teams_list = utils._get_stats_table(doc, 'div#all_team-stats-base')
         opp_teams_list = utils._get_stats_table(doc,
                                                 'div#all_opponent-stats-base')
+        if not teams_list and not opp_teams_list:
+            utils._no_data_found()
+            return
         for stats_list in [teams_list, opp_teams_list]:
             team_data_dict = self._add_stats_data(stats_list, team_data_dict)
 

--- a/sportsreference/ncaab/schedule.py
+++ b/sportsreference/ncaab/schedule.py
@@ -491,6 +491,9 @@ class Schedule:
                 year = str(int(year) - 1)
         doc = pq(SCHEDULE_URL % (abbreviation.lower(), year))
         schedule = utils._get_stats_table(doc, 'table#schedule')
+        if not schedule:
+            utils._no_data_found()
+            return
 
         for item in schedule:
             if 'class="thead"' in str(item):

--- a/sportsreference/ncaab/teams.py
+++ b/sportsreference/ncaab/teams.py
@@ -1130,7 +1130,10 @@ class Teams:
         adv_teams_list = utils._get_stats_table(doc, 'table#adv_school_stats')
         doc = pq(ADVANCED_OPPONENT_STATS_URL % year)
         adv_opp_list = utils._get_stats_table(doc, 'table#adv_opp_stats')
-
+        if not teams_list and not opp_list and not adv_teams_list \
+           and not adv_opp_list:
+            utils._no_data_found()
+            return
         for stats_list in [teams_list, opp_list, adv_teams_list, adv_opp_list]:
             team_data_dict = self._add_stats_data(stats_list, team_data_dict)
 

--- a/sportsreference/ncaaf/schedule.py
+++ b/sportsreference/ncaaf/schedule.py
@@ -448,6 +448,9 @@ class Schedule:
                 year = str(int(year) - 1)
         doc = pq(SCHEDULE_URL % (abbreviation.lower(), year))
         schedule = utils._get_stats_table(doc, 'table#schedule')
+        if not schedule:
+            utils._no_data_found()
+            return
 
         for item in schedule:
             game = Game(item)

--- a/sportsreference/ncaaf/teams.py
+++ b/sportsreference/ncaaf/teams.py
@@ -584,6 +584,9 @@ class Teams:
         teams_list = utils._get_stats_table(doc, 'div#div_standings')
         offense_doc = pq(OFFENSIVE_STATS_URL % year)
         offense_list = utils._get_stats_table(offense_doc, 'table#offense')
+        if not teams_list and not offense_list:
+            utils._no_data_found()
+            return
         for stats_list in [teams_list, offense_list]:
             team_data_dict = self._add_stats_data(stats_list, team_data_dict)
 

--- a/sportsreference/nfl/schedule.py
+++ b/sportsreference/nfl/schedule.py
@@ -670,6 +670,9 @@ class Schedule:
                 year = str(int(year) - 1)
         doc = pq(SCHEDULE_URL % (abbreviation.lower(), year))
         schedule = utils._get_stats_table(doc, 'table#gamelog%s' % year)
+        if not schedule:
+            utils._no_data_found()
+            return
         self._add_games_to_schedule(schedule, REGULAR_SEASON, year)
         if 'playoff_gamelog%s' % year in str(doc):
             playoffs = utils._get_stats_table(doc,

--- a/sportsreference/nfl/teams.py
+++ b/sportsreference/nfl/teams.py
@@ -635,6 +635,9 @@ class Teams:
         teams_list = utils._get_stats_table(doc, 'div#all_team_stats')
         afc_list = utils._get_stats_table(doc, 'table#AFC')
         nfc_list = utils._get_stats_table(doc, 'table#NFC')
+        if not teams_list and not afc_list and not nfc_list:
+            utils._no_data_found()
+            return
         for stats_list in [teams_list, afc_list, nfc_list]:
             team_data_dict = self._add_stats_data(stats_list, team_data_dict)
 

--- a/sportsreference/nhl/schedule.py
+++ b/sportsreference/nhl/schedule.py
@@ -585,6 +585,9 @@ class Schedule:
                 year = str(int(year) - 1)
         doc = pq(SCHEDULE_URL % (abbreviation, year))
         schedule = utils._get_stats_table(doc, 'table#tm_gamelog_rs')
+        if not schedule:
+            utils._no_data_found()
+            return
 
         for item in schedule:
             if 'class="thead"' in str(item):

--- a/sportsreference/nhl/teams.py
+++ b/sportsreference/nhl/teams.py
@@ -484,6 +484,9 @@ class Teams:
         teams_list = utils._get_stats_table(doc, 'div#all_stats')
         # Teams are listed in terms of rank with the first team being #1
         rank = 1
+        if not teams_list:
+            utils._no_data_found()
+            return
         for team_data in teams_list:
             team = Team(team_data, rank, year)
             self._teams.append(team)

--- a/sportsreference/utils.py
+++ b/sportsreference/utils.py
@@ -257,3 +257,19 @@ def _get_stats_table(html_page, div, footer=False):
     else:
         teams_list = stats_table('tbody tr').items()
     return teams_list
+
+
+def _no_data_found():
+    """
+    Print a message that no data could be found on the page.
+
+    Occasionally, such as right before the beginning of a season, a page will
+    return a valid response but will have no data outside of the default
+    HTML and CSS template. With no data present on the page, sportsreference
+    can't parse any information and should indicate the lack of data and return
+    safely.
+    """
+    print('The requested page returned a valid response, but no data could be '
+          'found. Has the season begun, and is the data available on '
+          'www.sports-reference.com?')
+    return

--- a/tests/integration/schedule/test_mlb_schedule.py
+++ b/tests/integration/schedule/test_mlb_schedule.py
@@ -176,6 +176,18 @@ class TestMLBSchedule:
         with pytest.raises(ValueError):
             self.schedule(datetime.now())
 
+    def test_empty_page_return_no_games(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        schedule = Schedule('NYY')
+
+        assert len(schedule) == 0
+
 
 class TestMLBScheduleInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/schedule/test_nba_schedule.py
+++ b/tests/integration/schedule/test_nba_schedule.py
@@ -144,6 +144,18 @@ class TestNBASchedule:
         with pytest.raises(ValueError):
             self.schedule(datetime.now())
 
+    def test_empty_page_return_no_games(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        schedule = Schedule('GSW')
+
+        assert len(schedule) == 0
+
 
 class TestNBAScheduleInvalidError:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/schedule/test_ncaab_schedule.py
+++ b/tests/integration/schedule/test_ncaab_schedule.py
@@ -147,6 +147,18 @@ class TestNCAABSchedule:
         with pytest.raises(ValueError):
             self.schedule(datetime.now())
 
+    def test_empty_page_return_no_games(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        schedule = Schedule('KANSAS')
+
+        assert len(schedule) == 0
+
 
 class TestNCAABScheduleInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/schedule/test_ncaaf_schedule.py
+++ b/tests/integration/schedule/test_ncaaf_schedule.py
@@ -145,6 +145,18 @@ class TestNCAAFSchedule:
         with pytest.raises(ValueError):
             self.schedule(datetime.now())
 
+    def test_empty_page_return_no_games(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        schedule = Schedule('MICHIGAN')
+
+        assert len(schedule) == 0
+
 
 class TestNCAAFScheduleInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/schedule/test_nfl_schedule.py
+++ b/tests/integration/schedule/test_nfl_schedule.py
@@ -167,6 +167,18 @@ class TestNFLSchedule:
         with pytest.raises(ValueError):
             self.schedule(datetime.now())
 
+    def test_empty_page_return_no_games(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        schedule = Schedule('NWE')
+
+        assert len(schedule) == 0
+
 
 class TestNFLScheduleInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/schedule/test_nhl_schedule.py
+++ b/tests/integration/schedule/test_nhl_schedule.py
@@ -159,6 +159,18 @@ class TestNHLSchedule:
         with pytest.raises(ValueError):
             self.schedule(datetime.now())
 
+    def test_empty_page_return_no_games(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        schedule = Schedule('NYR')
+
+        assert len(schedule) == 0
+
 
 class TestNHLScheduleInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/teams/test_mlb_integration.py
+++ b/tests/integration/teams/test_mlb_integration.py
@@ -254,3 +254,15 @@ class TestMLBIntegration:
 
         for team in teams:
             assert team._year == '2017'
+
+    def test_mlb_empty_page_returns_no_teams(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        teams = Teams()
+
+        assert len(teams) == 0

--- a/tests/integration/teams/test_nba_integration.py
+++ b/tests/integration/teams/test_nba_integration.py
@@ -155,6 +155,18 @@ class TestNBAIntegration:
         with pytest.raises(ValueError):
             self.teams('INVALID_NAME')
 
+    def test_nba_empty_page_returns_no_teams(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        teams = Teams()
+
+        assert len(teams) == 0
+
 
 class TestNBAIntegrationInvalidDate:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/teams/test_ncaab_integration.py
+++ b/tests/integration/teams/test_ncaab_integration.py
@@ -659,6 +659,18 @@ class TestNCAABIntegration:
         with pytest.raises(ValueError):
             self.teams('INVALID_NAME')
 
+    def test_ncaab_empty_page_returns_no_teams(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        teams = Teams()
+
+        assert len(teams) == 0
+
 
 class TestNCAABIntegrationInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/teams/test_ncaaf_integration.py
+++ b/tests/integration/teams/test_ncaaf_integration.py
@@ -318,6 +318,18 @@ class TestNCAAFIntegration:
         with pytest.raises(ValueError):
             self.teams('INVALID_NAME')
 
+    def test_ncaaf_empty_page_returns_no_teams(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        teams = Teams()
+
+        assert len(teams) == 0
+
 
 class TestNCAAFIntegrationInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/teams/test_nfl_integration.py
+++ b/tests/integration/teams/test_nfl_integration.py
@@ -149,6 +149,18 @@ class TestNFLIntegration:
         with pytest.raises(ValueError):
             self.teams('INVALID_NAME')
 
+    def test_nfl_empty_page_returns_no_teams(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        teams = Teams()
+
+        assert len(teams) == 0
+
 
 class TestNFLIntegrationInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/integration/teams/test_nhl_integration.py
+++ b/tests/integration/teams/test_nhl_integration.py
@@ -135,6 +135,18 @@ class TestNHLIntegration:
         with pytest.raises(ValueError):
             self.teams('INVALID_NAME')
 
+    def test_nhl_empty_page_returns_no_teams(self):
+        flexmock(utils) \
+            .should_receive('_no_data_found') \
+            .once()
+        flexmock(utils) \
+            .should_receive('_get_stats_table') \
+            .and_return(None)
+
+        teams = Teams()
+
+        assert len(teams) == 0
+
 
 class TestNHLIntegrationInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -286,3 +286,8 @@ class TestUtils:
         response = utils._url_exists('http://www.exception.com')
 
         assert not response
+
+    def test_no_data_found_returns_safely(self, *args, **kwargs):
+        response = utils._no_data_found()
+
+        assert not response


### PR DESCRIPTION
Occasionally, such as right before the beginning of a season, a page will return a valid response but will have no data outside of the default HTML and CSS template. With no data present on the page, `sportsreference` can't parse any information and should indicate the lack of data and return safely.

Fixes #164

Signed-Off-By: Robert Clark <robdclark@outlook.com>