### PR TITLE
Add passing_yards to NCAAF players

### DIFF
--- a/sportsreference/ncaaf/boxscore.py
+++ b/sportsreference/ncaaf/boxscore.py
@@ -77,7 +77,6 @@ class BoxscorePlayer(AbstractPlayer):
     def __init__(self, player_id, player_name, player_data):
         self._index = 0
         self._player_id = player_id
-        self._passing_yards = None
         self._pass_yards_per_attempt = None
         self._kickoff_returns = None
         self._kickoff_return_yards = None
@@ -164,14 +163,6 @@ class BoxscorePlayer(AbstractPlayer):
             'punting_yards_per_punt': self.punting_yards_per_attempt
         }
         return pd.DataFrame([fields_to_include], index=[self._player_id])
-
-    @_int_property_decorator
-    def passing_yards(self):
-        """
-        Returns an ``int`` of the total number of yards the player gained from
-        passing the ball.
-        """
-        return self._passing_yards
 
     @_float_property_decorator
     def pass_yards_per_attempt(self):

--- a/sportsreference/ncaaf/player.py
+++ b/sportsreference/ncaaf/player.py
@@ -76,6 +76,7 @@ class AbstractPlayer:
         self._pass_attempts = None
         self._passing_completion = None
         self._passing_touchdowns = None
+        self._passing_yards = None
         self._interceptions_thrown = None
         self._passing_yards_per_attempt = None
         self._adjusted_yards_per_attempt = None
@@ -230,6 +231,14 @@ class AbstractPlayer:
         receiver. Percentage ranges from 0-100.
         """
         return self._passing_completion
+
+    @_int_property_decorator
+    def passing_yards(self):
+        """
+        Returns an ``int`` of the total number of yards the player gained from
+        passing the ball.
+        """
+        return self._passing_yards
 
     @_int_property_decorator
     def passing_touchdowns(self):

--- a/sportsreference/ncaaf/roster.py
+++ b/sportsreference/ncaaf/roster.py
@@ -78,6 +78,7 @@ class Player(AbstractPlayer):
         self._completed_passes = None
         self._pass_attempts = None
         self._passing_completion = None
+        self._passing_yards = None
         self._passing_touchdowns = None
         self._interceptions_thrown = None
         self._passing_yards_per_attempt = None
@@ -391,6 +392,7 @@ class Player(AbstractPlayer):
             'passes_defended': self.passes_defended,
             'passing_completion': self.passing_completion,
             'passing_touchdowns': self.passing_touchdowns,
+            'passing_yards': self.passing_yards,
             'passing_yards_per_attempt': self.passing_yards_per_attempt,
             'player_id': self.player_id,
             'plays_from_scrimmage': self.plays_from_scrimmage,
@@ -546,6 +548,14 @@ class Player(AbstractPlayer):
         receiver. Percentage ranges from 0-100.
         """
         return self._passing_completion
+
+    @_int_property_decorator
+    def passing_yards(self):
+        """
+        Returns an ``int`` of the total number of yards the player gained from
+        passing the ball.
+        """
+        return self._passing_yards
 
     @_int_property_decorator
     def passing_touchdowns(self):


### PR DESCRIPTION
The `passing_yards` attribute was missing for NCAAF players that were retrieved from the Roster module. A link to `passing_yards` was misplaced and it should have been included in the `AbstractPlayer` class to ensure it was available everywhere the `AbstractPlayer` class was inherited. With the property added to the `AbstractPlayer` class, it is now accessible in the Roster module.

Fixes #158 

Signed-Off-By: Robert Clark <robdclark@outlook.com>