### PR TITLE
Fix issue parsing NCAAB games without times

### DIFF
--- a/sportsreference/ncaab/schedule.py
+++ b/sportsreference/ncaab/schedule.py
@@ -197,7 +197,17 @@ class Game:
         Returns a datetime object to indicate the month, day, year, and time
         the requested game took place.
         """
-        date_string = '%s %s' % (self._date, self._time.upper())
+        # Sometimes, the time isn't displayed on the game page. In this case,
+        # the time property will be empty, causing the time parsing to fail as
+        # it can't match the expected format. To prevent the issue, and since
+        # the time can't properly be parsed, a default start time of 7:00PM
+        # should be used in this scenario as 7:00PM appears to be the average
+        # start time for NCAAB games.
+        if not self._time or self._time.upper() == '':
+            time = '7:00P'
+        else:
+            time = self._time.upper()
+        date_string = '%s %s' % (self._date, time)
         date_string = re.sub(r'/.*', '', date_string)
         date_string = re.sub(r' ET', '', date_string)
         date_string += 'M'

--- a/tests/unit/test_ncaab_schedule.py
+++ b/tests/unit/test_ncaab_schedule.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from flexmock import flexmock
 from mock import PropertyMock
 from pyquery import PyQuery as pq
@@ -126,6 +127,22 @@ class TestNCAABSchedule:
         type(self.game)._overtimes = fake_overtime
 
         assert self.game.overtimes == 0
+
+    def test_none_time_defaults_to_set_time_in_datetime(self):
+        fake_date = PropertyMock(return_value='Thu, Dec 13, 2018')
+        fake_time = PropertyMock(return_value=None)
+        type(self.game)._date = fake_date
+        type(self.game)._time = fake_time
+
+        assert self.game.datetime == datetime(2018, 12, 13, 19, 0)
+
+    def test_blank_time_defaults_to_set_time_in_datetime(self):
+        fake_date = PropertyMock(return_value='Thu, Dec 13, 2018')
+        fake_time = PropertyMock(return_value='')
+        type(self.game)._date = fake_date
+        type(self.game)._time = fake_time
+
+        assert self.game.datetime == datetime(2018, 12, 13, 19, 0)
 
     def test_empty_schedule_class_returns_dataframe_of_none(self):
         fake_points = PropertyMock(return_value=None)


### PR DESCRIPTION
A few NCAAB games are posted on www.sports-reference.com without a listed game start time. In this scenario, the Game class will throw an error attempting to parse the time and create a datetime for the game. In the case a game doesn't include a time, a default of 7:00PM should be used as it tends to be a common start time for NCAAB games.

Fixes #116

Signed-Off-By: Robert Clark <robdclark@outlook.com>