### PR TITLE
Set default NCAAB time to midnight

### DIFF
--- a/sportsreference/ncaab/schedule.py
+++ b/sportsreference/ncaab/schedule.py
@@ -200,11 +200,11 @@ class Game:
         # Sometimes, the time isn't displayed on the game page. In this case,
         # the time property will be empty, causing the time parsing to fail as
         # it can't match the expected format. To prevent the issue, and since
-        # the time can't properly be parsed, a default start time of 7:00PM
-        # should be used in this scenario as 7:00PM appears to be the average
-        # start time for NCAAB games.
+        # the time can't properly be parsed, a default start time of midnight
+        # should be used in this scenario, allowing users to decide if and how
+        # they want to handle the time being empty.
         if not self._time or self._time.upper() == '':
-            time = '7:00P'
+            time = '12:00A'
         else:
             time = self._time.upper()
         date_string = '%s %s' % (self._date, time)

--- a/tests/unit/test_ncaab_schedule.py
+++ b/tests/unit/test_ncaab_schedule.py
@@ -134,7 +134,7 @@ class TestNCAABSchedule:
         type(self.game)._date = fake_date
         type(self.game)._time = fake_time
 
-        assert self.game.datetime == datetime(2018, 12, 13, 19, 0)
+        assert self.game.datetime == datetime(2018, 12, 13, 0, 0)
 
     def test_blank_time_defaults_to_set_time_in_datetime(self):
         fake_date = PropertyMock(return_value='Thu, Dec 13, 2018')
@@ -142,7 +142,7 @@ class TestNCAABSchedule:
         type(self.game)._date = fake_date
         type(self.game)._time = fake_time
 
-        assert self.game.datetime == datetime(2018, 12, 13, 19, 0)
+        assert self.game.datetime == datetime(2018, 12, 13, 0, 0)
 
     def test_empty_schedule_class_returns_dataframe_of_none(self):
         fake_points = PropertyMock(return_value=None)


### PR DESCRIPTION
In case an NCAAB game doesn't have a time value associated with it, the default time should be set to midnight instead of 7:00PM as users should have the option on how to handle missing data instead of providing false information. Now, users can check if the `time` property is empty and determine how they want to treat the data in such cases.

Signed-Off-By: Robert Clark <robdclark@outlook.com>