### PR TITLE
Fix issue with boxscores throwing errors

### DIFF
--- a/sportsreference/ncaaf/boxscore.py
+++ b/sportsreference/ncaaf/boxscore.py
@@ -700,8 +700,9 @@ class Boxscore:
         values. The index for the DataFrame is the string URI that is used to
         instantiate the class, such as '2018-01-08-georgia'.
         """
-        if self._away_points is None and self._home_points is None:
-            return None
+        for points in [self._away_points, self._home_points]:
+            if points is None or points == '':
+                return None
         fields_to_include = {
             'away_first_downs': self.away_first_downs,
             'away_fumbles': self.away_fumbles,


### PR DESCRIPTION
For games that are yet to occur which are listed in an NCAAF team's schedule, an error will be thrown while attempting to parse a score for the game when none exists. To circumvent this issue, not only should the points be checked if they are `None`, they should also be checked if they are empty.

Fixes #184

Signed-Off-By: Robert Clark <robdclark@outlook.com>