### PR TITLE
Fix NBA Boxscore integration tests

### DIFF
--- a/tests/integration/boxscore/test_nba_boxscore.py
+++ b/tests/integration/boxscore/test_nba_boxscore.py
@@ -165,14 +165,12 @@ class TestNBABoxscore:
         assert df1.empty
 
     def test_nba_boxscore_players(self):
-        boxscore = Boxscore(BOXSCORE)
+        assert len(self.boxscore.home_players) == 13
+        assert len(self.boxscore.away_players) == 13
 
-        assert len(boxscore.home_players) == 13
-        assert len(boxscore.away_players) == 13
-
-        for player in boxscore.home_players:
+        for player in self.boxscore.home_players:
             assert not player.dataframe.empty
-        for player in boxscore.away_players:
+        for player in self.boxscore.away_players:
             assert not player.dataframe.empty
 
 


### PR DESCRIPTION
The NBA Boxscore integration tests randomly started failing while attempting to create an instance of the Boxscore class. The issue is now resolved, allowing the tests to complete as expected again.

Fixes #200

Signed-Off-By: Robert Clark <robdclark@outlook.com>