### PR TITLE
Support NBA players from Chad

### DIFF
--- a/sportsreference/nba/constants.py
+++ b/sportsreference/nba/constants.py
@@ -304,6 +304,7 @@ NATIONALITY = {
     'bg': 'Bulgaria',
     'cm': 'Cameroon',
     'ca': 'Canada',
+    'td': 'Chad',
     'co': 'Colombia',
     'cv': 'Cape Verde',
     'cn': 'China',


### PR DESCRIPTION
With the addition of Christ Koumadje to the NBA, Chad is now a nation that is represented and should be supported by the project.

Fixes #167 

Signed-Off-By: Robert Clark <robdclark@outlook.com>