### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -1,0 +1,76 @@
+name: Sportsreference push tests
+
+on: [push]
+
+jobs:
+  test:
+    name: Test and lint code
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      max-parallel: 12
+      matrix:
+        python-version: [3.5, 3.6, 3.7]
+        operating-system: [ubuntu-latest, macOS-latest, windows-latest, windows-2016]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run unit and integration tests with pytest
+      run: |
+        py.test --cov=sportsreference --cov-report term-missing --cov-report xml tests/
+    - name: Lint with pycodestyle
+      run: |
+        pycodestyle sportsreference/ tests/
+    - name: Upload coverage to Codecov
+      if: matrix.operating-system == 'ubuntu-latest' && matrix.python-version == '3.7'
+      uses: codecov/codecov-action@v1.0.2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+  publish:
+    name: Publish package to PyPI
+    needs:
+      test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install setuptools wheel
+    - name: Update version for patch dev-release
+      if: github.event_name == 'push' && !startsWith(github.event.ref, 'refs/tags') && startsWith(github.context.ref, 'patch/')
+      run: |
+        ./dev-version-bump patch
+    - name: Update version for minor dev-release
+      if: github.event_name == 'push' && !startsWith(github.event.ref, 'refs/tags') && github.context.ref == 'master'
+      run: |
+        ./dev-version-bump minor
+    - name: Build wheel
+      run: |
+        python setup.py sdist bdist_wheel --universal
+    - name: Upload dev-releases to Test PyPI
+      if: github.event_name == 'push' && !startsWith(github.event.ref, 'refs/tags') && (github.context.ref == 'master' || startsWith(github.context.ref, 'patch/'))
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_PASSWORD }}
+        repository: https://test.pypi.org/legacy
+    - name: Upload tagged releases to PyPI
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Given the limitations of Travis-CI such as delayed or stalled builds, erroneous errors and failures, frequent timeouts, and lack of support for Windows, it would be preferable to move to GitHub Actions to solve the above issues as well as reduce the number of third-party integrations with this repository.

Fixes #199

Signed-Off-By: Robert Clark <robdclark@outlook.com>