### PR TITLE
Fix identical home and away scores in NBA Boxscore

### DIFF
--- a/sportsreference/nba/constants.py
+++ b/sportsreference/nba/constants.py
@@ -173,7 +173,7 @@ BOXSCORE_ELEMENT_INDEX = {
     'home_blocks': 1,
     'home_turnovers': 1,
     'home_personal_fouls': 1,
-    'home_points': 1,
+    'home_points': -1,
     'home_true_shooting_percentage': 1,
     'home_effective_field_goal_percentage': 1,
     'home_three_point_attempt_rate': 1,


### PR DESCRIPTION
The NBA Boxscores module contains an issue where both the home and away points will return just the away team's points. The HTML has changed on the website in a way that multiple scores are returned instead of just a singular score for home and away, throwing the indexing off for selecting the home team's points. Selecting the final index for the home team's points total works in the case that multiple instances are used for the score.

Fixes #207

Signed-Off-By: Robert Clark <robdclark@outlook.com>