### PR TITLE
Add support for Peru in MLB

### DIFF
--- a/sportsreference/mlb/constants.py
+++ b/sportsreference/mlb/constants.py
@@ -479,6 +479,7 @@ NATIONALITY = {
     'ni': 'Nicaragua',
     'no': 'Norway',
     'pa': 'Panama',
+    'pe': 'Peru',
     'ph': 'Philippines',
     'pl': 'Poland',
     'pt': 'Portugal',


### PR DESCRIPTION
Jesus Luzardo becomes the first MLB player from Peru. As a result, support should be added for Peru in the list of nationalities.

Fixes #211

Signed-Off-By: Robert Clark <robdclark@outlook.com>