### PR TITLE
Fix HTTP redirect issues in NCAAB module

### DIFF
--- a/sportsreference/ncaab/constants.py
+++ b/sportsreference/ncaab/constants.py
@@ -305,18 +305,18 @@ PLAYER_SCHEME = {
     'defensive_rating': 'td[data-stat="def_rtg"]'
 }
 
-BASIC_STATS_URL = ('http://www.sports-reference.com/cbb/seasons/'
+BASIC_STATS_URL = ('https://www.sports-reference.com/cbb/seasons/'
                    '%s-school-stats.html')
-BASIC_OPPONENT_STATS_URL = ('http://www.sports-reference.com/cbb/seasons/'
+BASIC_OPPONENT_STATS_URL = ('https://www.sports-reference.com/cbb/seasons/'
                             '%s-opponent-stats.html')
-ADVANCED_STATS_URL = ('http://www.sports-reference.com/cbb/seasons/'
+ADVANCED_STATS_URL = ('https://www.sports-reference.com/cbb/seasons/'
                       '%s-advanced-school-stats.html')
-ADVANCED_OPPONENT_STATS_URL = ('http://www.sports-reference.com/cbb/seasons/'
+ADVANCED_OPPONENT_STATS_URL = ('https://www.sports-reference.com/cbb/seasons/'
                                '%s-advanced-opponent-stats.html')
 
-SCHEDULE_URL = ('http://www.sports-reference.com/cbb/schools/%s/'
+SCHEDULE_URL = ('https://www.sports-reference.com/cbb/schools/%s/'
                 '%s-schedule.html')
-BOXSCORE_URL = 'http://www.sports-reference.com/cbb/boxscores/%s.html'
+BOXSCORE_URL = 'https://www.sports-reference.com/cbb/boxscores/%s.html'
 BOXSCORES_URL = ('https://www.sports-reference.com/cbb/boxscores/index.cgi?'
                  'month=%s&day=%s&year=%s')
 RANKINGS_URL = 'https://www.sports-reference.com/cbb/seasons/%s-polls-old.html'


### PR DESCRIPTION
The NCAAB module was throwing unhandled HTTP 301 status codes for all pages, which masked 404 errors in the case of pages not being present, and therefore allowing false positives for pulling data from the website. The 301 codes were being thrown as the server automatically redirects from http:// to https:// for the linked pages, and should therefore default to https:// for the URLs to ensure proper codes are always returned while pulling webpages.

Fixes #215

Signed-Off-By: Robert Clark <robdclark@outlook.com>