### PR TITLE
Resolve errors while pulling empty NBA stats pages

### DIFF
--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -168,6 +168,8 @@ class Player(AbstractPlayer):
         self._contract = None
 
         player_data = self._pull_player_data()
+        if not player_data:
+            return
         self._find_initial_index()
         AbstractPlayer.__init__(self, player_id, self._name, player_data)
 
@@ -484,6 +486,8 @@ class Player(AbstractPlayer):
             stats.
         """
         player_info = self._retrieve_html_page()
+        if not player_info:
+            return
         self._parse_player_information(player_info)
         self._parse_nationality(player_info)
         self._parse_birth_date(player_info)

--- a/tests/unit/test_nba_roster.py
+++ b/tests/unit/test_nba_roster.py
@@ -37,10 +37,7 @@ class TestNBAPlayer:
             .should_receive('_parse_player_data') \
             .and_return(None)
         flexmock(Player) \
-            .should_receive('_pull_player_data') \
-            .and_return(None)
-        flexmock(Player) \
-            .should_receive('_find_initial_index') \
+            .should_receive('__init__') \
             .and_return(None)
 
     def test_no_float_returns_default_value_abstract_class(self):
@@ -105,3 +102,14 @@ class TestNBAPlayer:
         result = player._parse_contract(player_info)
 
         assert player._contract is None
+
+
+class TestInvalidNBAPlayer:
+    def test_no_player_data_returns_no_stats(self):
+        flexmock(Player) \
+            .should_receive('_retrieve_html_page') \
+            .and_return(None)
+
+        stats = Player(None)._pull_player_data()
+
+        assert stats is None


### PR DESCRIPTION
Some players don't have a personal stats page created for them yet, but contain a valid link on roster pages. As implemented, the Roster module for the NBA does not check if the returned data from the page is empty, and will attempt to parse information from an object which is `None`. Instead, if a player's page is invalid, the module should fail-fast and return `None` for the player instead of attempting to parse information or handle other scenarios.

Fixes #217

Signed-Off-By: Robert Clark <robdclark@outlook.com>