### PR TITLE
Fix issue with future NFL boxscore errors

### DIFF
--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -652,8 +652,9 @@ class Boxscore:
         values. The index for the DataFrame is the string URI that is used to
         instantiate the class, such as '201802040nwe'.
         """
-        if self._away_points is None and self._home_points is None:
-            return None
+        for points in [self._away_points, self._home_points]:
+            if points is None or points == '':
+                return None
         fields_to_include = {
             'attendance': self.attendance,
             'away_first_downs': self.away_first_downs,


### PR DESCRIPTION
For games that are yet to occur which are listed in an NFL team's schedule, an error will be thrown while attempting to parse a score for the game when none exists. To circumvent this issue, not only should the points be checked if they are `None`, they should also be checked if they are empty.

Fixes #219

Signed-Off-By: Robert Clark <robdclark@outlook.com>