### PR TITLE
Fix missing players for legacy NBA boxscores

### DIFF
--- a/sportsreference/nba/boxscore.py
+++ b/sportsreference/nba/boxscore.py
@@ -360,8 +360,8 @@ class Boxscore:
         Find all tables with boxscore information on the page.
 
         Iterate through all tables on the page and see if any of them are
-        boxscore pages by checking if the ID is prefixed with 'box_'. If so,
-        add it to a list and return the final list at the end.
+        boxscore pages by checking if the ID is prefixed with 'box_' or 'box-'.
+        If so, add it to a list and return the final list at the end.
 
         Parameters
         ----------
@@ -378,7 +378,7 @@ class Boxscore:
 
         for table in boxscore('table').items():
             try:
-                if 'box_' in table.attr['id']:
+                if 'box_' in table.attr['id'] or 'box-' in table.attr['id']:
                     tables.append(table)
             except (KeyError, TypeError):
                 continue


### PR DESCRIPTION
While searching older NBA boxscores, the players lists will sometimes appear empty as the package is unable to pull the boxscore tables on the requested page. The table ID's have been changed in some cases from being pre-fixed with 'box_' to 'box-'. As a result, both prefixes should be checked while attempting to pull relevant tables.

Fixes #222

Signed-Off-By: Robert Clark <robdclark@outlook.com>