### PR TITLE
Fix issue pulling empty NBA roster fields

### DIFF
--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -1320,6 +1320,8 @@ class Roster:
         players = page('table#roster tbody tr').items()
         for player in players:
             player_id = self._get_id(player)
+            if not player_id or player_id == '':
+                continue  # pragma: no cover
             if self._slim:
                 name = self._get_name(player)
                 self._players[player_id] = name

--- a/tests/integration/roster/test_nba_roster.py
+++ b/tests/integration/roster/test_nba_roster.py
@@ -1259,3 +1259,16 @@ class TestNBARoster:
         for player in roster.players:
             assert player.name in ['James Harden', 'Tarik Black',
                                    'Ryan Anderson', 'Trevor Ariza']
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_empty_rows_are_skipped(self, *args, **kwargs):
+        flexmock(utils) \
+            .should_receive('_find_year_for_season') \
+            .and_return('2018')
+        flexmock(Roster) \
+            .should_receive('_get_id') \
+            .and_return(None)
+
+        roster = Roster('HOU')
+
+        assert len(roster.players) == 0


### PR DESCRIPTION
Occasionally, some NBA roster pages will include empty rows in the roster table, causing the code to think another player exists when one doesn't, throwing an error when it is unable to parse a player ID. If an empty row is ever encountered, it should just be skipped as no information can be parsed anyway.

Fixes #226

Signed-Off-By: Robert Clark <robdclark@outlook.com>