### PR TITLE
nfl.schedule.Game.result return win/loss/tie/unknown correctly

### DIFF
--- a/sportsreference/constants.py
+++ b/sportsreference/constants.py
@@ -1,5 +1,6 @@
 WIN = 'Win'
 LOSS = 'Loss'
+TIE = 'Tie'
 HOME = 'Home'
 AWAY = 'Away'
 NEUTRAL = 'Neutral'

--- a/sportsreference/nfl/schedule.py
+++ b/sportsreference/nfl/schedule.py
@@ -284,7 +284,7 @@ class Game:
         """
         Returns a ``string`` constant indicating whether the team won or lost
         the game. NFL games may end in a tie if the score is even at the end of
-        OT. If a game has no result (canceled, yet to be played, etc.) return 
+        OT. If a game has no result (canceled, yet to be played, etc.) return
         ``None``.
         """
         if self._result.lower() == 'l':

--- a/sportsreference/nfl/schedule.py
+++ b/sportsreference/nfl/schedule.py
@@ -8,6 +8,7 @@ from pyquery import PyQuery as pq
 from sportsreference import utils
 from sportsreference.constants import (WIN,
                                        LOSS,
+                                       TIE,
                                        HOME,
                                        AWAY,
                                        NEUTRAL,
@@ -282,11 +283,19 @@ class Game:
     def result(self):
         """
         Returns a ``string`` constant indicating whether the team won or lost
-        the game.
+        the game.  
+        NFL games may end in a tie if the score is even at the end of OT.  
+        If a game has no result (canceled, yet to be played, etc.) return 
+        ``None``
         """
         if self._result.lower() == 'l':
             return LOSS
-        return WIN
+        elif self._result.lower() == 'w':
+            return WIN
+        elif self._result.lower() == 't':
+            return TIE
+        else:
+            return None
 
     @property
     def overtime(self):

--- a/sportsreference/nfl/schedule.py
+++ b/sportsreference/nfl/schedule.py
@@ -283,10 +283,9 @@ class Game:
     def result(self):
         """
         Returns a ``string`` constant indicating whether the team won or lost
-        the game.  
-        NFL games may end in a tie if the score is even at the end of OT.  
-        If a game has no result (canceled, yet to be played, etc.) return 
-        ``None``
+        the game. NFL games may end in a tie if the score is even at the end of
+        OT. If a game has no result (canceled, yet to be played, etc.) return 
+        ``None``.
         """
         if self._result.lower() == 'l':
             return LOSS

--- a/tests/unit/test_nfl_schedule.py
+++ b/tests/unit/test_nfl_schedule.py
@@ -3,6 +3,7 @@ from mock import PropertyMock
 from sportsreference.constants import (AWAY,
                                        HOME,
                                        LOSS,
+                                       TIE,
                                        NEUTRAL,
                                        POST_SEASON,
                                        REGULAR_SEASON,
@@ -54,6 +55,18 @@ class TestNFLSchedule:
         type(self.game)._result = fake_result
 
         assert self.game.result == LOSS
+
+    def test_tied_result_returns_tie(self):
+        fake_result = PropertyMock(return_value='T')
+        type(self.game)._result = fake_result
+
+        assert self.game.result == TIE
+
+    def test_no_result_returns_none(self):
+        fake_result = PropertyMock(return_value='')
+        type(self.game)._result = fake_result
+
+        assert self.game.result == None
 
     def test_overtime_returns_overtime(self):
         fake_overtime = PropertyMock(return_value='OT')

--- a/tests/unit/test_nfl_schedule.py
+++ b/tests/unit/test_nfl_schedule.py
@@ -66,7 +66,7 @@ class TestNFLSchedule:
         fake_result = PropertyMock(return_value='')
         type(self.game)._result = fake_result
 
-        assert self.game.result == None
+        assert self.game.result is None
 
     def test_overtime_returns_overtime(self):
         fake_overtime = PropertyMock(return_value='OT')


### PR DESCRIPTION
1. Add a constant `TIE` to represent NFL games that can end in a tie, at the end of overtime.
2. in `schedule.Game.result`, consider all possible outcomes of an NFL game, instead of returning WIN indiscriminately if the if-statement does not evaluate to true. Check whether the result is l/w/t and return the corresponding constant. If none of the above match, return None

`closes #245`