### PR TITLE
Update NFL season URL

### DIFF
--- a/sportsreference/nfl/constants.py
+++ b/sportsreference/nfl/constants.py
@@ -352,7 +352,7 @@ PLAYER_SCHEME = {
     'punt_return_touchdowns': 'td[data-stat="punt_ret_td"]'
 }
 
-SEASON_PAGE_URL = 'http://www.pro-football-reference.com/years/%s.html'
+SEASON_PAGE_URL = 'http://www.pro-football-reference.com/years/%s/'
 
 SCHEDULE_URL = 'https://www.pro-football-reference.com/teams/%s/%s/gamelog/'
 


### PR DESCRIPTION
PFF's season page moved to a new URL. Updating `SEASON_PAGE_URL` in `nfl.constants` to reflect the change.