### PR TITLE
Trigger actions on Pull Requests

### DIFF
--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -1,6 +1,6 @@
 name: Sportsreference push tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
The checks run by GitHub Actions are only triggered when a branch is pushed to the parent (non-fork) repository, but don't run when a PR is created. This is an issue when anyone creates a PR based on a fork they have created, preventing any collaborators from having their code reviewed automatically.

Fixes #252

Signed-Off-By: Robert Clark <robdclark@outlook.com>