### PR TITLE
Fix incorrect home records in NBA boxscores

### DIFF
--- a/sportsreference/nba/boxscore.py
+++ b/sportsreference/nba/boxscore.py
@@ -591,12 +591,16 @@ class Boxscore:
                 setattr(self, field, value)
                 continue
             index = 0
+            strip = False
             if short_field in BOXSCORE_ELEMENT_INDEX.keys():
                 index = BOXSCORE_ELEMENT_INDEX[short_field]
+            if short_field == 'home_record':
+                strip = True
             value = utils._parse_field(BOXSCORE_SCHEME,
                                        boxscore,
                                        short_field,
-                                       index)
+                                       index,
+                                       strip)
             setattr(self, field, value)
         self._away_players, self._home_players = self._find_players(boxscore)
 

--- a/sportsreference/nba/constants.py
+++ b/sportsreference/nba/constants.py
@@ -151,7 +151,7 @@ BOXSCORE_SCHEME = {
 BOXSCORE_ELEMENT_INDEX = {
     'date': 0,
     'location': 1,
-    'home_record': 2,
+    'home_record': -1,
     'home_minutes_played': 1,
     'home_field_goals': 1,
     'home_field_goal_attempts': 1,

--- a/sportsreference/utils.py
+++ b/sportsreference/utils.py
@@ -148,7 +148,7 @@ def _parse_abbreviation(uri_link):
     return abbr.upper()
 
 
-def _parse_field(parsing_scheme, html_data, field, index=0):
+def _parse_field(parsing_scheme, html_data, field, index=0, strip=False):
     """
     Parse an HTML table to find the requested field's value.
 
@@ -177,6 +177,11 @@ def _parse_field(parsing_scheme, html_data, field, index=0):
         hit, or the number of home runs a pitcher has given up. The index
         aligns with the order in which the attributes are recevied in the
         html_data parameter.
+    strip : boolean (optional)
+        An optional boolean value which will remove any empty or invalid
+        elements which might show up during list comprehensions. Specify True
+        if the invalid elements should be removed from lists, which can help
+        with reverse indexing.
 
     Returns
     -------
@@ -187,7 +192,10 @@ def _parse_field(parsing_scheme, html_data, field, index=0):
     if field == 'abbreviation':
         return _parse_abbreviation(html_data)
     scheme = parsing_scheme[field]
-    items = [i.text() for i in html_data(scheme).items()]
+    if strip:
+        items = [i.text() for i in html_data(scheme).items() if i.text()]
+    else:
+        items = [i.text() for i in html_data(scheme).items()]
     # Stats can be added and removed on a yearly basis. If not stats are found,
     # return None and have the be the value.
     if len(items) == 0:


### PR DESCRIPTION
The NBA Boxscore class was pulling the incorrect home record in some scenarios. Instead of picking a particular index, the home team's record should be the final index as a non-deterministic amount of records could be displayed on a page, but the home team will always be last.

Fixes #230

Signed-Off-By: Robert Clark <robdclark@outlook.com>