### PR TITLE
Fix encoding issues with player names in tests

### DIFF
--- a/tests/exhaustive/mlb_tests.py
+++ b/tests/exhaustive/mlb_tests.py
@@ -5,7 +5,10 @@ from sportsreference.mlb.teams import Teams
 for team in Teams():
     print(team.name)
     for player in team.roster.players:
-        print(player.name)
+        try:
+            print(player.name)
+        except UnicodeEncodeError:
+            print(player.name.encode('utf-8'))
     for game in team.schedule:
         print(game.dataframe)
         print(game.dataframe_extended)

--- a/tests/exhaustive/nba_tests.py
+++ b/tests/exhaustive/nba_tests.py
@@ -5,7 +5,10 @@ from sportsreference.nba.teams import Teams
 for team in Teams():
     print(team.name)
     for player in team.roster.players:
-        print(player.name)
+        try:
+            print(player.name)
+        except UnicodeEncodeError:
+            print(player.name.encode('utf-8'))
     for game in team.schedule:
         print(game.dataframe)
         print(game.dataframe_extended)


### PR DESCRIPTION
The exhaustive tests are throwing errors on the Windows tests when it tries to parse players that have accents in their names. To prevent the errors from being thrown and the tests from failing, this should be caught and handled properly.

Fixes #259

Signed-Off-By: Robert Clark <robdclark@outlook.com>