### PR TITLE
Remove limit on parallel jobs

### DIFF
--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -7,7 +7,6 @@ jobs:
     name: Test and lint code
     runs-on: ${{ matrix.operating-system }}
     strategy:
-      max-parallel: 12
       matrix:
         python-version: [3.5, 3.6, 3.7]
         operating-system: [ubuntu-latest, macOS-latest, windows-latest, windows-2016]


### PR DESCRIPTION
The push tests in GitHub Actions was setting a limit on the maximum number of jobs that can be run in parallel. This becomes an issue when a large number of jobs are spawned concurrently, and makes updates much slower than necessary.

Fixes #272

Signed-Off-By: Robert Clark <robdclark@outlook.com>