### PR TITLE
Support Python 3.8

### DIFF
--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -13,7 +13,7 @@ jobs:
       # Prevent the entire workflow from failing if a singular test fails.
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         operating-system: [ubuntu-latest, macOS-latest, windows-latest]
         sport: ['MLB', 'NBA', 'NCAAB', 'NCAAF', 'NFL', 'NHL']
 

--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         operating-system: [ubuntu-latest, macOS-latest, windows-latest, windows-2016]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'License :: OSI Approved :: MIT License',
         'Operating System :: POSIX :: Linux',
     ),


### PR DESCRIPTION
Now that Python 3.8 is generally available, support should be added for the newest version.

Closes #277

Signed-Off-By: Robert Clark <robdclark@outlook.com>