### PR TITLE
Add game summary for NCAAF boxscores

### DIFF
--- a/sportsreference/ncaaf/constants.py
+++ b/sportsreference/ncaaf/constants.py
@@ -143,6 +143,7 @@ BOXSCORE_SCHEME = {
     'date': 'div[class="scorebox_meta"]:first',
     'time': 'div[class="scorebox_meta"]:first',
     'stadium': 'div[class="scorebox_meta"]:first',
+    'summary': 'table[class="linescore nohover stats_table no_freeze"]:first',
     'home_name': 'a[itemprop="name"]:last',
     'away_name': 'a[itemprop="name"]:first',
     'away_points': 'div[class="scorebox"] div[class="score"]',

--- a/tests/integration/boxscore/test_ncaaf_boxscore.py
+++ b/tests/integration/boxscore/test_ncaaf_boxscore.py
@@ -95,6 +95,10 @@ class TestNCAAFBoxscore:
     def test_ncaaf_boxscore_returns_requested_boxscore(self):
         for attribute, value in self.results.items():
             assert getattr(self.boxscore, attribute) == value
+        assert getattr(self.boxscore, 'summary') == {
+            'away': [0, 0, 10, 10, 6],
+            'home': [0, 13, 7, 0, 3]
+        }
 
     def test_invalid_url_yields_empty_class(self):
         flexmock(Boxscore) \

--- a/tests/unit/test_ncaaf_boxscore.py
+++ b/tests/unit/test_ncaaf_boxscore.py
@@ -282,6 +282,27 @@ class TestNCAAFBoxscore:
 
         assert self.boxscore.losing_abbr == expected_name
 
+    def test_game_summary_with_no_scores_returns_none(self):
+        result = Boxscore(None)._parse_summary(pq(
+            """<table class="linescore nohover stats_table no_freeze">
+    <tbody>
+        <tr>
+            <td class="center"></td>
+            <td class="center"></td>
+        </tr>
+        <tr>
+            <td class="center"></td>
+            <td class="center"></td>
+        </tr>
+    </tbody>
+</table>"""
+        ))
+
+        assert result == {
+            'away': [None],
+            'home': [None]
+        }
+
     def test_invalid_url_returns_none(self):
         result = Boxscore(None)._retrieve_html_page('')
 


### PR DESCRIPTION
A game summary including a quarter-by-quarter score should be included as an attribute to the NCAAF Boxscores class, which returns a dictionary of both the home and away team's score per quarter, including any overtime results.

Closes #225

Signed-Off-By: Robert Clark <robdclark@outlook.com>