### PR TITLE
Add game summary for NFL boxscores

### DIFF
--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -237,6 +237,7 @@ class Boxscore:
         self._winning_abbr = None
         self._losing_name = None
         self._losing_abbr = None
+        self._summary = None
         self._away_points = None
         self._away_first_downs = None
         self._away_rush_attempts = None
@@ -381,6 +382,51 @@ class Boxscore:
         """
         scheme = BOXSCORE_SCHEME[field]
         return pq(str(boxscore(scheme)).strip())
+
+    def _parse_summary(self, boxscore):
+        """
+        Find the game summary including score in each quarter.
+
+        The game summary provides further information on the points scored
+        during each quarter, including the final score and any overtimes if
+        applicable. The final output will be in a dictionary with two keys,
+        'away' and 'home'. The value of each key will be a list for each
+        respective team's score by order of the quarter, with the first element
+        belonging to the first quarter, similar to the following:
+
+        {
+            'away': [0, 7, 3, 14],
+            'home': [7, 7, 3, 0]
+        }
+
+        Parameters
+        ----------
+        boxscore : PyQuery object
+            A PyQuery object containing all of the HTML from the boxscore.
+
+        Returns
+        -------
+        dict
+            Returns a ``dictionary`` representing the score for each team in
+            each quarter of the game.
+        """
+        team = ['away', 'home']
+        summary = {'away': [], 'home': []}
+        game_summary = boxscore(BOXSCORE_SCHEME['summary'])
+        for ind, team_info in enumerate(game_summary('tbody tr').items()):
+            # Only pull the first N-1 items as the last element is the final
+            # score for each team which is already stored in an attribute, and
+            # shouldn't be duplicated.
+            for quarter in list(team_info('td[class="center"]').items())[:-1]:
+                # The first element contains the logo and name of the teams,
+                # but not any score information, and should be skipped.
+                if quarter('div'):
+                    continue
+                try:
+                    summary[team[ind]].append(int(quarter.text()))
+                except ValueError:
+                    summary[team[ind]].append(None)
+        return summary
 
     def _find_boxscore_tables(self, boxscore):
         """
@@ -634,6 +680,10 @@ class Boxscore:
                 value = self._parse_name(short_field, boxscore)
                 setattr(self, field, value)
                 continue
+            if short_field == 'summary':
+                value = self._parse_summary(boxscore)
+                setattr(self, field, value)
+                continue
             index = 0
             if short_field in BOXSCORE_ELEMENT_INDEX.keys():
                 index = BOXSCORE_ELEMENT_INDEX[short_field]
@@ -786,6 +836,21 @@ class Boxscore:
         Returns a ``string`` of the game's duration in the format 'H:MM'.
         """
         return self._duration
+
+    @property
+    def summary(self):
+        """
+        Returns a ``dictionary`` with two keys, 'away' and 'home'. The value of
+        each key will be a list for each respective team's score by order of
+        the quarter, with the first element belonging to the first quarter,
+        similar to the following:
+
+        {
+            'away': [0, 7, 3, 14],
+            'home': [7, 7, 3, 0]
+        }
+        """
+        return self._summary
 
     @property
     def winner(self):

--- a/sportsreference/nfl/constants.py
+++ b/sportsreference/nfl/constants.py
@@ -78,6 +78,7 @@ SCHEDULE_SCHEME = {
 BOXSCORE_SCHEME = {
     'game_info': 'div[class="scorebox_meta"]:first',
     'home_name': 'a[itemprop="name"]:first',
+    'summary': 'table[class="linescore nohover stats_table no_freeze"]:first',
     'away_name': 'a[itemprop="name"]:last',
     'away_points': 'div[class="scorebox"] div[class="score"]',
     'away_first_downs': 'td[data-stat="vis_stat"]',

--- a/tests/integration/boxscore/test_nfl_boxscore.py
+++ b/tests/integration/boxscore/test_nfl_boxscore.py
@@ -113,6 +113,10 @@ class TestNFLBoxscore:
     def test_nfl_boxscore_returns_requested_boxscore(self):
         for attribute, value in self.results.items():
             assert getattr(self.boxscore, attribute) == value
+        assert getattr(self.boxscore, 'summary') == {
+            'away': [9, 13, 7, 12],
+            'home': [3, 9, 14, 7]
+        }
 
     def test_invalid_url_yields_empty_class(self):
         flexmock(Boxscore) \

--- a/tests/unit/test_nfl_boxscore.py
+++ b/tests/unit/test_nfl_boxscore.py
@@ -177,6 +177,26 @@ class TestNFLBoxscore:
 
         assert self.boxscore.losing_abbr == expected_name
 
+    def test_game_summary_with_no_scores_returns_none(self):
+        result = Boxscore(None)._parse_summary(pq(
+            """<table class="linescore nohover stats_table no_freeze">
+    <tbody>
+        <tr>
+            <td class="center"></td>
+            <td class="center"></td>
+        </tr>
+        <tr>
+            <td class="center"></td>
+            <td class="center"></td>
+        </tr>
+    </tbody>
+</table>"""))
+
+        assert result == {
+            'away': [None],
+            'home': [None]
+        }
+
     @patch('requests.get', side_effect=mock_pyquery)
     def test_invalid_url_returns_none(self, *args, **kwargs):
         result = Boxscore(None)._retrieve_html_page('bad')


### PR DESCRIPTION
A game summary including a quarter-by-quarter score should be included as an attribute to the NFL Boxscores class, which returns a dictionary of both the home and away team's score per quarter, including any overtime results.

Closes #286

Signed-Off-By: Robert Clark <robdclark@outlook.com>