### PR TITLE
Add game summary for NBA boxscores

### DIFF
--- a/sportsreference/nba/boxscore.py
+++ b/sportsreference/nba/boxscore.py
@@ -207,6 +207,7 @@ class Boxscore:
         self._losing_name = None
         self._losing_abbr = None
         self._pace = None
+        self._summary = None
         self._away_record = None
         self._away_minutes_played = None
         self._away_field_goals = None
@@ -354,6 +355,48 @@ class Boxscore:
         """
         scheme = BOXSCORE_SCHEME[field]
         return boxscore(scheme)
+
+    def _parse_summary(self, boxscore):
+        """
+        Find the game summary including score in each quarter.
+
+        The game summary provides further information on the points scored
+        during each quarter, including the final score and any overtimes if
+        applicable. The final output will be in a dictionary with two keys,
+        'away' and 'home'. The value of each key will be a list for each
+        respective team's score by order of the quarter, with the first element
+        belonging to the first quarter, similar to the following:
+
+        {
+            'away': [23, 40, 23, 24],
+            'home': [30, 27, 34, 30]
+        }
+
+        Parameters
+        ----------
+        boxscore : PyQuery object
+            A PyQuery object containing all of the HTML from the boxscore.
+
+        Returns
+        -------
+        dict
+            Returns a ``dictionary`` representing the score for each team in
+            each quarter of the game.
+        """
+        team = ['away', 'home']
+        summary = {'away': [], 'home': []}
+        game_summary = boxscore(BOXSCORE_SCHEME['summary'])
+        for ind, team_info in enumerate(game_summary('tr').items()):
+            # Only pull the first N-1 items as the last element is the final
+            # score for each team which is already stored in an attribute, and
+            # shouldn't be duplicated.
+            for quarter in list(team_info('td[class="center"]').items())[:-1]:
+                ind = ind % 2
+                try:
+                    summary[team[ind]].append(int(quarter.text()))
+                except ValueError:
+                    summary[team[ind]].append(None)
+        return summary
 
     def _find_boxscore_tables(self, boxscore):
         """
@@ -590,6 +633,10 @@ class Boxscore:
                 value = self._parse_name(short_field, boxscore)
                 setattr(self, field, value)
                 continue
+            if short_field == 'summary':
+                value = self._parse_summary(boxscore)
+                setattr(self, field,  value)
+                continue
             index = 0
             strip = False
             if short_field in BOXSCORE_ELEMENT_INDEX.keys():
@@ -750,6 +797,21 @@ class Boxscore:
         played.
         """
         return self._location
+
+    @property
+    def summary(self):
+        """
+        Returns a ``dictionary`` with two keys, 'away' and 'home'. The value of
+        each key will be a list for each respective team's score by order of
+        the quarter, with the first element belonging to the first quarter,
+        similar to the following:
+
+        {
+            'away': [23, 40, 23, 24],
+            'home': [30, 27, 34, 30]
+        }
+        """
+        return self._summary
 
     @property
     def winner(self):

--- a/sportsreference/nba/constants.py
+++ b/sportsreference/nba/constants.py
@@ -73,6 +73,7 @@ BOXSCORE_SCHEME = {
     'winning_abbr': '',
     'losing_name': '',
     'losing_abbr': '',
+    'summary': 'table#line_score',
     'pace': 'td[data-stat="pace"]:first',
     'away_record': 'div[class="table_wrapper"] h2',
     'away_minutes_played': 'tfoot td[data-stat="mp"]',

--- a/tests/integration/boxscore/test_nba_boxscore.py
+++ b/tests/integration/boxscore/test_nba_boxscore.py
@@ -137,6 +137,10 @@ class TestNBABoxscore:
     def test_nba_boxscore_returns_requested_boxscore(self):
         for attribute, value in self.results.items():
             assert getattr(self.boxscore, attribute) == value
+        assert getattr(self.boxscore, 'summary') == {
+            'away': [22, 23, 27, 21],
+            'home': [25, 33, 29, 26]
+        }
 
     def test_invalid_url_yields_empty_class(self):
         flexmock(Boxscore) \

--- a/tests/unit/test_nba_boxscore.py
+++ b/tests/unit/test_nba_boxscore.py
@@ -189,6 +189,27 @@ class TestNBABoxscore:
 
         assert self.boxscore.home_losses == 0
 
+    def test_game_summary_with_no_scores_returns_none(self):
+        result = Boxscore(None)._parse_summary(pq(
+            """<table id="line_score">
+    <tbody>
+        <tr>
+            <td class="center"></td>
+            <td class="center"></td>
+        </tr>
+        <tr>
+            <td class="center"></td>
+            <td class="center"></td>
+        </tr>
+    </tbody>
+</table>"""
+        ))
+
+        assert result == {
+            'away': [None],
+            'home': [None]
+        }
+
     def test_invalid_url_returns_none(self):
         result = Boxscore(None)._retrieve_html_page('')
 


### PR DESCRIPTION
A game summary including a quarter-by-quarter score should be included as an attribute to the NBA Boxscores class, which returns a dictionary of both the home and away team's score per quarter, including any overtime results.

Closes #302

Signed-Off-By: Robert Clark <robdclark@outlook.com>