### PR TITLE
Add game summary for NCAAB boxscores

### DIFF
--- a/sportsreference/ncaab/constants.py
+++ b/sportsreference/ncaab/constants.py
@@ -116,6 +116,7 @@ BOXSCORE_SCHEME = {
     'winning_abbr': '',
     'losing_name': '',
     'losing_abbr': '',
+    'summary': 'table#line-score',
     'pace': 'td[data-stat="pace"]:first',
     'away_record': 'div#boxes div[class="section_heading"] h2',
     'away_minutes_played': 'tfoot td[data-stat="mp"]',

--- a/tests/integration/boxscore/test_ncaab_boxscore.py
+++ b/tests/integration/boxscore/test_ncaab_boxscore.py
@@ -144,6 +144,10 @@ class TestNCAABBoxscore:
     def test_ncaab_boxscore_returns_requested_boxscore(self):
         for attribute, value in self.results.items():
             assert getattr(self.boxscore, attribute) == value
+        assert getattr(self.boxscore, 'summary') == {
+            'away': [33, 31],
+            'home': [50, 39]
+        }
 
     def test_invalid_url_yields_empty_class(self):
         flexmock(Boxscore) \

--- a/tests/unit/test_ncaab_boxscore.py
+++ b/tests/unit/test_ncaab_boxscore.py
@@ -312,6 +312,27 @@ class TestNCAABBoxscore:
 
         assert self.boxscore.home_losses == 0
 
+    def test_game_summary_with_no_scores_returns_none(self):
+        result = Boxscore(None)._parse_summary(pq(
+            """<table id="line-score">
+    <tbody>
+        <tr>
+            <td class="right"></td>
+            <td class="right"></td>
+        </tr>
+        <tr>
+            <td class="right"></td>
+            <td class="right"></td>
+        </tr>
+    </tbody>
+</table>"""
+        ))
+
+        assert result == {
+            'away': [None],
+            'home': [None]
+        }
+
     def test_invalid_url_returns_none(self):
         result = Boxscore(None)._retrieve_html_page('')
 


### PR DESCRIPTION
A game summary including a half-by-half score should be included as an attribute to the NCAAB Boxscores class, which returns a dictionary of both the home and away team's score per half, including any overtime results.

Fixes #304 

Signed-Off-By: Robert Clark <robdclark@outlook.com>