### PR TITLE
Add game summary for MLB boxscores

### DIFF
--- a/sportsreference/mlb/constants.py
+++ b/sportsreference/mlb/constants.py
@@ -144,6 +144,7 @@ BOXSCORE_SCHEME = {
     'away_name': 'a[itemprop="name"]:first',
     'home_name': 'a[itemprop="name"]:last',
     'winner': 'td[data-stat=""]',
+    'summary': 'table[class="linescore nohover stats_table no_freeze"]',
     'winning_name': 'td[data-stat=""]',
     'winning_abbr': 'td[data-stat=""]',
     'losing_name': 'td[data-stat=""]',

--- a/tests/integration/boxscore/test_mlb_boxscore.py
+++ b/tests/integration/boxscore/test_mlb_boxscore.py
@@ -139,6 +139,10 @@ class TestMLBBoxscore:
     def test_mlb_boxscore_returns_requested_boxscore(self):
         for attribute, value in self.results.items():
             assert getattr(self.boxscore, attribute) == value
+        assert getattr(self.boxscore, 'summary') == {
+            'away': [5, 0, 1, 0, 0, 0, 0, 1, 0],
+            'home': [1, 0, 0, 0, 1, 0, 0, 0, 0]
+        }
 
     def test_invalid_url_yields_empty_class(self):
         flexmock(Boxscore) \

--- a/tests/unit/test_mlb_boxscore.py
+++ b/tests/unit/test_mlb_boxscore.py
@@ -169,6 +169,31 @@ class TestMLBBoxscore:
 
         assert self.boxscore.losing_abbr == expected_name
 
+    def test_game_summary_with_no_scores_returns_none(self):
+        result = Boxscore(None)._parse_summary(pq(
+            """<table class="linescore nohover stats_table no_freeze">
+    <tbody>
+        <tr>
+            <td class="center"></td>
+            <td class="center"></td>
+            <td class="center"></td>
+            <td class="center"></td>
+        </tr>
+        <tr>
+            <td class="center"></td>
+            <td class="center"></td>
+            <td class="center"></td>
+            <td class="center"></td>
+        </tr>
+    </tbody>
+</table>"""
+        ))
+
+        assert result == {
+            'away': [None],
+            'home': [None]
+        }
+
     @patch('requests.get', side_effect=mock_pyquery)
     def test_invalid_url_returns_none(self, *args, **kwargs):
         result = Boxscore(None)._retrieve_html_page('')


### PR DESCRIPTION
A game summary including a inning-by-inning score should be included as an attribute to the MLB Boxscores class, which returns a dictionary of both the home and away team's score per half, including any extra inning results.

Closes #306

Signed-Off-By: Robert Clark <robdclark@outlook.com>