### PR TITLE
Add post-season result for NFL teams

### DIFF
--- a/sportsreference/nfl/constants.py
+++ b/sportsreference/nfl/constants.py
@@ -367,3 +367,9 @@ WILD_CARD = 100
 DIVISION = 101
 CONF_CHAMPIONSHIP = 102
 SUPER_BOWL = 103
+
+LOST_WILD_CARD = 'Lost WC'
+LOST_DIVISIONAL = 'Lost Divisional'
+LOST_CONF_CHAMPS = 'Lost Conference Championship'
+LOST_SUPER_BOWL = 'Lost Super Bowl'
+WON_SUPER_BOWL = 'Won Super Bowl'

--- a/sportsreference/nfl/teams.py
+++ b/sportsreference/nfl/teams.py
@@ -1,7 +1,18 @@
 import pandas as pd
 import re
-from .constants import PARSING_SCHEME, SEASON_PAGE_URL
+from .constants import (CONF_CHAMPIONSHIP,
+                        DIVISION,
+                        LOST_CONF_CHAMPS,
+                        LOST_DIVISIONAL,
+                        LOST_SUPER_BOWL,
+                        LOST_WILD_CARD,
+                        PARSING_SCHEME,
+                        SEASON_PAGE_URL,
+                        SUPER_BOWL,
+                        WILD_CARD,
+                        WON_SUPER_BOWL)
 from pyquery import PyQuery as pq
+from ..constants import LOSS, WIN
 from ..decorators import float_property_decorator, int_property_decorator
 from .. import utils
 from .roster import Roster
@@ -139,6 +150,7 @@ class Team:
             self.points_contributed_by_offense,
             'points_difference': self.points_difference,
             'points_for': self.points_for,
+            'post_season_result': self.post_season_result,
             'rank': self.rank,
             'rush_attempts': self.rush_attempts,
             'rush_first_downs': self.rush_first_downs,
@@ -226,6 +238,28 @@ class Team:
         Returns an ``int`` of the number of games played during the season.
         """
         return self._games_played
+
+    @property
+    def post_season_result(self):
+        """
+        Returns a ``string constant`` denoting how far the team made it in the
+        post-season.
+        """
+        final_game = self.schedule[-1]
+        result = final_game.result
+        if result == LOSS and final_game.week in [WILD_CARD, 18]:
+            return LOST_WILD_CARD
+        if result == LOSS and final_game.week in [DIVISION, 19]:
+            return LOST_DIVISIONAL
+        if result == LOSS and final_game.week in [CONF_CHAMPIONSHIP, 20]:
+            return LOST_CONF_CHAMPS
+        if result == LOSS and final_game.week in [SUPER_BOWL, 21]:
+            return LOST_SUPER_BOWL
+        if result == WIN and final_game.week in [SUPER_BOWL, 21]:
+            return WON_SUPER_BOWL
+        # If none of the above conditions are true, the team failed to qualify
+        # for the post-season.
+        return None
 
     @int_property_decorator
     def points_for(self):

--- a/tests/integration/teams/test_nfl_integration.py
+++ b/tests/integration/teams/test_nfl_integration.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from flexmock import flexmock
 from sportsreference import utils
-from sportsreference.nfl.constants import SEASON_PAGE_URL
+from sportsreference.nfl.constants import LOST_WILD_CARD, SEASON_PAGE_URL
 from sportsreference.nfl.teams import Teams
 
 
@@ -65,6 +65,7 @@ class TestNFLIntegration:
             'wins': 10,
             'losses': 6,
             'win_percentage': .625,
+            'post_season_result': LOST_WILD_CARD,
             'games_played': 16,
             'points_for': 415,
             'points_against': 339,


### PR DESCRIPTION
A new property is added which indicates how far an NFL team made it in the post-season, if at all. This allows quick queries to see if the team made it to a particular round, or if they won or lost one of the playoff games.

Fixes #242

Signed-Off-By: Robert Clark <robdclark@outlook.com>