### PR TITLE
Fix issue pulling missing NCAAB player weight

### DIFF
--- a/sportsreference/ncaab/roster.py
+++ b/sportsreference/ncaab/roster.py
@@ -524,6 +524,8 @@ class Player(AbstractPlayer):
         """
         Returns an ``int`` of the player's weight in pounds.
         """
+        if not self._weight:
+            return None
         return int(self._weight.replace('lb', ''))
 
     @_int_property_decorator

--- a/tests/unit/test_ncaab_roster.py
+++ b/tests/unit/test_ncaab_roster.py
@@ -99,3 +99,12 @@ class TestNCAABPlayer:
         result = player._combine_season_stats(None, None, {})
 
         assert result == {}
+
+    def test_player_with_no_weight_returns_none(self):
+        mock_weight = PropertyMock(return_value=None)
+        player = Player(None)
+        type(player)._weight = mock_weight
+
+        result = player.weight
+
+        assert result is None


### PR DESCRIPTION
Occasionally, some NCAAB players will not have a weight listed on their stats page on sports-reference.com. This will return `None` for the property in the Player class. While attempting to parse the weight from None, an error will be thrown. Doing a simple check to see if the weight is valid prior to parsing will resolve the issue and allow execution as expected.

Fixes #298

Signed-Off-By: Robert Clark <robdclark@outlook.com>