### PR TITLE
Fix issue pulling empty NBA roster page

### DIFF
--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -206,7 +206,7 @@ class Player(AbstractPlayer):
         url = self._build_url()
         try:
             url_data = pq(url)
-        except HTTPError:
+        except (HTTPError, ParserError):
             return None
         return pq(utils._remove_html_comment_tags(url_data))
 


### PR DESCRIPTION
Occasionally, an NBA team's roster page on sports-reference.com will be empty, causing an error to be thrown while attempting to parse the page. Adding an additional check to see if the page is parsable will gracefully handle situations where the page is invalid.

Fixes #337

Signed-Off-By: Robert Clark <robdclark@outlook.com>