### PR TITLE
Add NCAAF player receiving stats

### DIFF
--- a/sportsreference/ncaaf/roster.py
+++ b/sportsreference/ncaaf/roster.py
@@ -254,7 +254,8 @@ class Player(AbstractPlayer):
         """
         all_stats_dict = {}
 
-        for table_id in ['passing', 'rushing', 'defense', 'scoring']:
+        for table_id in ['passing', 'rushing', 'defense', 'scoring',
+                         'receiving']:
             table_items = utils._get_stats_table(player_info,
                                                  'table#%s' % table_id)
             career_items = utils._get_stats_table(player_info,


### PR DESCRIPTION
For a handful of NCAAF players, the "Receiving & Rushing" table has an ID of `receiving` instead of the commonly-used `rushing`. The former was not being parsed, and the relevant stats were ignored for those players. Simply adding that ID to the list of tables to parse resolves the issue.

Fixes #362

Signed-Off-By: Robert Clark <robdclark@outlook.com>