### PR TITLE
Skip NCAAB teams without stat pages

### DIFF
--- a/sportsreference/ncaab/teams.py
+++ b/sportsreference/ncaab/teams.py
@@ -1138,6 +1138,11 @@ class Teams:
             team_data_dict = self._add_stats_data(stats_list, team_data_dict)
 
         for team_name, team_data in team_data_dict.items():
+            # Skip any teams that don't have a valid team page, which is likely
+            # any school that doesn't compete in D-I, but is still in the stats
+            # list.
+            if team_name.lower() not in self._conferences_dict:
+                continue
             team = Team(team_data['data'],
                         self._conferences_dict[team_name.lower()],
                         year)

--- a/tests/integration/teams/test_ncaab_integration.py
+++ b/tests/integration/teams/test_ncaab_integration.py
@@ -671,6 +671,21 @@ class TestNCAABIntegration:
 
         assert len(teams) == 0
 
+    def test_ncaab_no_conference_info_skips_team(self):
+        flexmock(utils) \
+            .should_receive('_todays_date') \
+            .and_return(MockDateTime(YEAR, MONTH))
+        flexmock(Conferences) \
+            .should_receive('team_conference') \
+            .and_return({})
+        flexmock(Conferences) \
+            .should_receive('_find_conferences') \
+            .and_return(None)
+
+        teams = Teams()
+
+        assert len(teams) == 0
+
 
 class TestNCAABIntegrationInvalidYear:
     @mock.patch('requests.get', side_effect=mock_pyquery)


### PR DESCRIPTION
In 2010 and earlier years, some NCAAB teams, such as Bryant University, made the transition from Division-II or lower to Division-I basketball. This caused an issue on the website as sometimes those teams would be displayed in the overall school stats, but they would not have their own standalone stats page specific to their school. This would prevent the code from parsing the team's conference and other stats, and would throw an error while attempting to instantiate the team. Doing a simple check to see if the team exists in the conference dataset prior to checking instantiating the team mitigates this issue.

Fixes #365

Signed-Off-By: Robert Clark <robdclark@outlook.com>