### PR TITLE
Convert MLB innings pitched to float

### DIFF
--- a/sportsreference/mlb/boxscore.py
+++ b/sportsreference/mlb/boxscore.py
@@ -165,10 +165,12 @@ class BoxscorePlayer(AbstractPlayer):
         """
         return self._earned_runs_against
 
-    @_int_property_decorator
+    @_float_property_decorator
     def innings_pitched(self):
         """
-        Returns an ``int`` of the number of innings the player pitched in.
+        Returns a ``float`` of the number of innings the player pitched in.
+        Numbers ending in '.0' indicate complete innings, while numbers ending
+        in '.1' are for 1/3 of an inning, and '.2' is for 2/3 of an inning.
         """
         return self._innings_pitched
 


### PR DESCRIPTION
The BoxscorePlayer class for MLB currently forces the number of innings pitched per player to be an integer, truncating any partial innings they might have played. This makes the data incomplete and unreliable. Allowing the number of innings pitched to be a float will now indicate partial innings pitched, with results ending in '.1' or '.2' to indicate one third or two thirds of an inning pitched, respectively.

Fixes #295

Signed-Off-By: Robert Clark <robdclark@outlook.com>