### PR TITLE
Switch MLB Boxscore player teams

### DIFF
--- a/sportsreference/mlb/boxscore.py
+++ b/sportsreference/mlb/boxscore.py
@@ -754,11 +754,11 @@ class Boxscore:
 
         tables = self._find_boxscore_tables(boxscore)
         for table in tables:
-            home_or_away = HOME
+            home_or_away = AWAY
             # There are two tables per team with the odd tables belonging to
-            # the away team.
+            # the home team.
             if table_count % 2 == 1:
-                home_or_away = AWAY
+                home_or_away = HOME
             player_dict = self._extract_player_stats(table,
                                                      player_dict,
                                                      home_or_away)


### PR DESCRIPTION
The home and away players in the MLB Boxscore class were being saved in the opposite property, causing home players to show under away_players and vice-versa. The algorithm wrongly assumed the away team matched with odd-numbered tables, when the numbers are zero-based, and should instead match with even-numbered tables as a result.

Fixes #368

Signed-Off-By: Robert Clark <robdclark@outlook.com>