### PR TITLE
Remove unused dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-atomicwrites==1.3.0
 attrs==19.3.0
 certifi==2019.11.28
 chardet==3.0.4
@@ -6,7 +5,6 @@ coverage==5.0.4
 cssselect==1.1.0
 flexmock==0.10.4
 idna==2.9
-importlib-metadata==1.5.2
 lxml==4.5.0
 mock==3.0.5
 more-itertools==8.2.0
@@ -26,4 +24,3 @@ requests==2.23.0
 six==1.14.0
 urllib3==1.25.7
 wcwidth==0.1.9
-zipp==0.6.0


### PR DESCRIPTION
Several dependencies were still being carried-over from previous versions of Python that were supported, and should be removed to reduce bloat and make it easier to update existing dependencies.

Fixes #370

Signed-Off-By: Robert Clark <robdclark@outlook.com>