### PR TITLE
Fix issue pulling NFL rosters

### DIFF
--- a/sportsreference/nfl/roster.py
+++ b/sportsreference/nfl/roster.py
@@ -238,7 +238,7 @@ class Player(AbstractPlayer):
         url = self._build_url()
         try:
             url_data = pq(url)
-        except HTTPError:
+        except (HTTPError, ParserError):
             return None
         # For NFL, a 404 page doesn't actually raise a 404 error, so it needs
         # to be manually checked.


### PR DESCRIPTION
Certain NFL rosters contain links to individual player pages that are either invalid or incomplete, causing an error during the parsing step. This occurs more frequently with earlier seasons as many pages were invalid. Simply checking if a page is invalid prior to attempting to parse the information will prevent the error from being thrown, and allow expected execution to continue.

Fixes #376

Signed-Off-By: Robert Clark <robdclark@outlook.com>