### PR TITLE
Fix NFL datetimes for playoff games

### DIFF
--- a/sportsreference/nfl/schedule.py
+++ b/sportsreference/nfl/schedule.py
@@ -274,9 +274,14 @@ class Game:
         """
         Returns a datetime object representing the date the game was played.
         """
+        year = self._year
+        # Check if the first word of the date (the month) is either january or
+        # february, and increase the year by 1.
+        if self._date.split(' ')[0].lower() in ['january', 'february']:
+            year = int(year) + 1
         date_string = '%s %s %s' % (self._day,
                                     self._date,
-                                    self._year)
+                                    year)
         return datetime.strptime(date_string, '%a %B %d %Y')
 
     @property


### PR DESCRIPTION
For NFL teams that played in playoff games which took place after the New Year, the `datetime` in the schedule would be incorrect as it would use the default year instead of the actual year the game was played. Checking if the game was played in the first couple months of the year and incrementing the year by 1 if so resolves this issue as games being played in January or February of the same season are in a different calendar year.

Fixes #375

Signed-Off-By: Robert Clark <robdclark@outlook.com>