### PR TITLE
Handle football HTTP errors

### DIFF
--- a/sportsreference/fb/roster.py
+++ b/sportsreference/fb/roster.py
@@ -7,6 +7,7 @@ from pyquery import PyQuery as pq
 from sportsreference.utils import (_get_stats_table,
                                    _parse_field,
                                    _remove_html_comment_tags)
+from urllib.error import HTTPError
 
 
 class SquadPlayer:
@@ -1620,8 +1621,11 @@ class Roster:
             the string version of the row data for the matched player.
         """
         if not doc:
-            doc = pq(SQUAD_URL % self._squad_id)
-            doc = pq(_remove_html_comment_tags(doc))
+            try:
+                doc = pq(SQUAD_URL % self._squad_id)
+                doc = pq(_remove_html_comment_tags(doc))
+            except HTTPError:
+                return None
         stats_table = []
         player_data_dict = {}
 

--- a/sportsreference/fb/schedule.py
+++ b/sportsreference/fb/schedule.py
@@ -12,6 +12,7 @@ from sportsreference.constants import (AWAY,
                                        LOSS,
                                        NEUTRAL,
                                        WIN)
+from urllib.error import HTTPError
 
 
 class Game:
@@ -591,7 +592,10 @@ class Schedule:
         """
         if not doc:
             squad_id = _lookup_team(team_id)
-            doc = pq(SQUAD_URL % squad_id)
+            try:
+                doc = pq(SQUAD_URL % squad_id)
+            except HTTPError:
+                return
         # Most leagues use the 'ks_sched_all' tag for competitions, but some,
         # like the MLS in North America, use a different table ID.
         for table_id in ['table#ks_sched_all', 'table#ks_sched_10090']:

--- a/sportsreference/fb/team.py
+++ b/sportsreference/fb/team.py
@@ -6,6 +6,7 @@ from pyquery import PyQuery as pq
 from .roster import Roster
 from .schedule import Schedule
 from .squad_ids import SQUAD_IDS
+from urllib.error import HTTPError
 from .. import utils
 
 
@@ -280,7 +281,10 @@ class Team:
         the header for relevant information on the team including records,
         goals, manager, league results, and more.
         """
-        doc = pq(SQUAD_URL % self.squad_id)
+        try:
+            doc = pq(SQUAD_URL % self.squad_id)
+        except HTTPError:
+            return
         self._doc = doc
         self._parse_name(doc)
         self._parse_header(doc)


### PR DESCRIPTION
The website will occasionally throw HTTP errors for various reasons, ranging from gateway timeouts, to invalid pages, to invalid syntax. Regardless of the cause, any of these issues makes parsing pages
impossible, and should therefore be skipped.

Fixes #379

Signed-Off-By: Robert Clark <robdclark@outlook.com>