### PR TITLE
Remove universal wheels

### DIFF
--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -59,7 +59,7 @@ jobs:
         ./dev-version-bump minor
     - name: Build wheel
       run: |
-        python setup.py sdist bdist_wheel --universal
+        python setup.py sdist bdist_wheel
     - name: Upload dev-releases to Test PyPI
       if: github.event_name == 'push' && !startsWith(github.event.ref, 'refs/tags') && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/patch/'))
       uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
Instead of publishing universal wheels which support both Python 2 and Python 3, only Python 3-specific wheels should be built and published as this package no longer support Python 2.

Fixes #387 

Signed-Off-By: Robert Clark <robdclark@outlook.com>