### PR TITLE
Fix issue pulling football schedules and rosters

### DIFF
--- a/sportsreference/fb/team.py
+++ b/sportsreference/fb/team.py
@@ -311,6 +311,8 @@ class Team:
         Returns an instance of the Schedule class containing the team's
         complete schedule for the season.
         """
+        if not hasattr(self, '_doc'):
+            self._doc = None
         return Schedule(self.squad_id, self._doc)
 
     @property
@@ -319,6 +321,8 @@ class Team:
         Returns an instance of the Roster class containing instances of every
         player on the team.
         """
+        if not hasattr(self, '_doc'):
+            self._doc = None
         return Roster(self._squad_id, self._doc)
 
     @property

--- a/tests/unit/test_fb_team.py
+++ b/tests/unit/test_fb_team.py
@@ -167,10 +167,30 @@ class TestFBTeam:
 
         assert len(self.team.schedule) == 0
 
+    def test_fb_no_doc_returns_schedule(self):
+        flexmock(Team) \
+            .should_receive('__init__') \
+            .and_return(None)
+
+        team = Team('Tottenham Hotspur')
+        team._squad_id = '361ca564'
+
+        assert len(team.schedule) == 0
+
     def test_fb_roster_returns_roster(self):
         self.team._doc = None
 
         assert len(self.team.roster) == 0
+
+    def test_fb_no_doc_returns_roster(self):
+        flexmock(Team) \
+            .should_receive('__init__') \
+            .and_return(None)
+
+        team = Team('Tottenham Hotspur')
+        team._squad_id = '361ca564'
+
+        assert len(team.roster) == 0
 
 
 class TestFBTeamInvalidPage:


### PR DESCRIPTION
If the Team class for football is unable to pull a team's page, the document for the team will be invalid, and the '_doc' attribute will not exist for that team. While trying to pull the schedule or roster for that team, an error will be thrown that the '_doc' attribute does not
exist.

Simply checking if the attribute exists, and setting it to `None` if not will allow the Schedule and Roster modules to retry pulling the page again to see if it works.

Fixes #391 

Signed-Off-By: Robert Clark <robdclark@outlook.com>