### PR TITLE
NBA: adding TypeError checks around operations

### DIFF
--- a/sportsreference/nba/boxscore.py
+++ b/sportsreference/nba/boxscore.py
@@ -49,6 +49,7 @@ class BoxscorePlayer(AbstractPlayer):
         page. If the player appears in multiple tables, all of their
         information will appear in one single string concatenated together.
     """
+
     def __init__(self, player_id, player_name, player_data):
         self._index = 0
         self._player_id = player_id
@@ -195,6 +196,7 @@ class Boxscore:
         The relative link to the boxscore HTML page, such as
         '201710310LAL'.
     """
+
     def __init__(self, uri):
         self._uri = uri
         self._date = None
@@ -958,7 +960,11 @@ class Boxscore:
         Returns an ``int`` of the total number of two point field goals made
         by the away team.
         """
-        return self.away_field_goals - self.away_three_point_field_goals
+        try:
+            result = self.away_field_goals - self.away_three_point_field_goals
+        except TypeError:
+            result = None
+        return result
 
     @int_property_decorator
     def away_two_point_field_goal_attempts(self):
@@ -966,8 +972,12 @@ class Boxscore:
         Returns an ``int`` of the total number of two point field goal attempts
         by the away team.
         """
-        return self.away_field_goal_attempts - \
-            self.away_three_point_field_goal_attempts
+        try:
+            result = self.away_field_goal_attempts - \
+                self.away_three_point_field_goal_attempts
+        except TypeError:
+            result = None
+        return result
 
     @float_property_decorator
     def away_two_point_field_goal_percentage(self):
@@ -976,9 +986,14 @@ class Boxscore:
         by the number of two point field goal attempts by the away team.
         Percentage ranges from 0-1.
         """
-        result = float(self.away_two_point_field_goals) / \
-            float(self.away_two_point_field_goal_attempts)
-        return round(float(result), 3)
+        try:
+            result = float(self.away_two_point_field_goals) / \
+                float(self.away_two_point_field_goal_attempts)
+        except TypeError:
+            result = None
+        else:
+            result = round(float(result), 3)
+        return result
 
     @int_property_decorator
     def away_free_throws(self):
@@ -1263,7 +1278,11 @@ class Boxscore:
         Returns an ``int`` of the total number of two point field goals made
         by the home team.
         """
-        return self.home_field_goals - self.home_three_point_field_goals
+        try:
+            result = self.home_field_goals - self.home_three_point_field_goals
+        except TypeError:
+            result = None
+        return result
 
     @int_property_decorator
     def home_two_point_field_goal_attempts(self):
@@ -1271,8 +1290,12 @@ class Boxscore:
         Returns an ``int`` of the total number of two point field goal attempts
         by the home team.
         """
-        return self.home_field_goal_attempts - \
-            self.home_three_point_field_goal_attempts
+        try:
+            result = self.home_field_goal_attempts - \
+                self.home_three_point_field_goal_attempts
+        except TypeError:
+            result = None
+        return result
 
     @float_property_decorator
     def home_two_point_field_goal_percentage(self):
@@ -1281,9 +1304,14 @@ class Boxscore:
         by the number of two point field goal attempts by the home team.
         Percentage ranges from 0-1.
         """
-        result = float(self.home_two_point_field_goals) / \
-            float(self.home_two_point_field_goal_attempts)
-        return round(float(result), 3)
+        try:
+            result = float(self.home_two_point_field_goals) / \
+                float(self.home_two_point_field_goal_attempts)
+        except TypeError:
+            result = None
+        else:
+            result = round(float(result), 3)
+        return result
 
     @int_property_decorator
     def home_free_throws(self):
@@ -1502,6 +1530,7 @@ class Boxscores:
         empty, or if 'end_date' is prior to 'date', only the games from the day
         specified in the 'date' parameter will be saved.
     """
+
     def __init__(self, date, end_date=None):
         self._boxscores = {}
 

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -720,7 +720,11 @@ class Player(AbstractPlayer):
         """
         Returns an ``int`` of the player's weight in pounds.
         """
-        return int(self._weight.replace('lb', ''))
+        try:
+            result = int(self._weight.replace('lb', ''))
+        except AttributeError:
+            result = None
+        return result
 
     @property
     def birth_date(self):

--- a/tests/unit/test_nba_boxscore.py
+++ b/tests/unit/test_nba_boxscore.py
@@ -189,6 +189,142 @@ class TestNBABoxscore:
 
         assert self.boxscore.home_losses == 0
 
+    def test_away_two_point_field_goals_calc(self):
+        fake_none = PropertyMock(return_value=None)
+        fake_int = PropertyMock(return_value=5)
+
+        type(self.boxscore)._away_field_goals = fake_none
+        type(self.boxscore)._away_three_point_field_goals = fake_none
+
+        assert self.boxscore.away_two_point_field_goals is None
+
+        type(self.boxscore)._away_three_point_field_goals = fake_int
+        assert self.boxscore.away_two_point_field_goals is None
+
+        type(self.boxscore)._away_field_goals = fake_int
+        type(self.boxscore)._away_three_point_field_goals = fake_none
+
+        assert self.boxscore.away_two_point_field_goals is None
+
+        type(self.boxscore)._away_field_goals = fake_int
+        type(self.boxscore)._away_three_point_field_goals = fake_int
+
+        assert isinstance(self.boxscore.away_two_point_field_goals, int)
+
+    def test_away_two_point_field_goal_attempts_calc(self):
+        fake_none = PropertyMock(return_value=None)
+        fake_int = PropertyMock(return_value=5)
+
+        type(self.boxscore)._away_field_goal_attempts = fake_none
+        type(self.boxscore)._away_three_point_field_goal_attempts = fake_none
+
+        assert self.boxscore.away_two_point_field_goal_attempts is None
+
+        type(self.boxscore)._away_three_point_field_goal_attempts = fake_int
+        assert self.boxscore.away_two_point_field_goal_attempts is None
+
+        type(self.boxscore)._away_field_goal_attempts = fake_int
+        type(self.boxscore)._away_three_point_field_goal_attempts = fake_none
+
+        assert self.boxscore.away_two_point_field_goal_attempts is None
+
+        type(self.boxscore)._away_field_goal_attempts = fake_int
+        type(self.boxscore)._away_three_point_field_goal_attempts = fake_int
+
+        assert isinstance(
+            self.boxscore.away_two_point_field_goal_attempts, int)
+
+    def test_away_two_point_field_goal_percentage_calc(self):
+        fake_none = PropertyMock(return_value=None)
+        fake_int = PropertyMock(return_value=5)
+
+        type(self.boxscore).away_two_point_field_goals = fake_none
+        type(self.boxscore).away_two_point_field_goal_attempts = fake_none
+
+        assert self.boxscore.away_two_point_field_goal_percentage is None
+
+        type(self.boxscore).away_two_point_field_goal_attempts = fake_int
+        assert self.boxscore.away_two_point_field_goal_percentage is None
+
+        type(self.boxscore).away_two_point_field_goals = fake_int
+        type(self.boxscore).away_two_point_field_goal_attempts = fake_none
+
+        assert self.boxscore.away_two_point_field_goal_percentage is None
+
+        type(self.boxscore).away_two_point_field_goals = fake_int
+        type(self.boxscore).away_two_point_field_goal_attempts = fake_int
+
+        assert isinstance(
+            self.boxscore.away_two_point_field_goal_percentage, float)
+
+    def test_home_to_point_field_goals_calc(self):
+        fake_none = PropertyMock(return_value=None)
+        fake_int = PropertyMock(return_vzalue=5)
+
+        type(self.boxscore)._home_field_goals = fake_none
+        type(self.boxscore)._home_three_point_field_goals = fake_none
+
+        assert self.boxscore.home_two_point_field_goals is None
+
+        type(self.boxscore)._home_three_point_field_goals = fake_int
+        assert self.boxscore.home_two_point_field_goals is None
+
+        type(self.boxscore)._home_field_goals = fake_int
+        type(self.boxscore)._home_three_point_field_goals = fake_none
+
+        assert self.boxscore.home_two_point_field_goals is None
+
+        type(self.boxscore)._home_field_goals = fake_int
+        type(self.boxscore)._home_three_point_field_goals = fake_int
+
+        assert isinstance(self.boxscore.home_two_point_field_goals, int)
+
+    def test_home_two_point_field_goal_attempts_calc(self):
+        fake_none = PropertyMock(return_value=None)
+        fake_int = PropertyMock(return_value=5)
+
+        type(self.boxscore)._home_field_goal_attempts = fake_none
+        type(self.boxscore)._home_three_point_field_goal_attempts = fake_none
+
+        assert self.boxscore.home_two_point_field_goal_attempts is None
+
+        type(self.boxscore)._home_three_point_field_goal_attempts = fake_int
+        assert self.boxscore.home_two_point_field_goal_attempts is None
+
+        type(self.boxscore)._home_field_goal_attempts = fake_int
+        type(self.boxscore)._home_three_point_field_goal_attempts = fake_none
+
+        assert self.boxscore.home_two_point_field_goal_attempts is None
+
+        type(self.boxscore)._home_field_goal_attempts = fake_int
+        type(self.boxscore)._home_three_point_field_goal_attempts = fake_int
+
+        assert isinstance(
+            self.boxscore.home_two_point_field_goal_attempts, int)
+
+    def test_home_two_point_field_goal_percentage_calc(self):
+        fake_none = PropertyMock(return_value=None)
+        fake_int = PropertyMock(return_value=5)
+
+        type(self.boxscore).home_two_point_field_goals = fake_none
+        type(self.boxscore).home_two_point_field_goal_attempts = fake_none
+
+        assert self.boxscore.home_two_point_field_goal_percentage is None
+
+        type(self.boxscore).home_two_point_field_goal_attempts = fake_int
+        assert self.boxscore.home_two_point_field_goal_percentage is None
+
+        type(self.boxscore).home_two_point_field_goals = fake_int
+        type(self.boxscore).home_two_point_field_goal_attempts = fake_none
+
+        assert self.boxscore.home_two_point_field_goal_percentage is None
+
+        type(self.boxscore).home_two_point_field_goals = fake_int
+        type(self.boxscore).home_two_point_field_goal_attempts = fake_int
+
+        assert isinstance(
+            self.boxscore.home_two_point_field_goal_percentage, float)
+
     def test_game_summary_with_no_scores_returns_none(self):
         result = Boxscore(None)._parse_summary(pq(
             """<table id="line_score">


### PR DESCRIPTION
This small PR simply adds some exception handling to some of the calculations for the NBA boxscore classes. 

I also intend to do this for the other classes as well. 

This was done because in the current state, running something like the following would raise a `TypeError`: 

```python
from sportsreference.nba.boxscore import Boxscore

bs = Boxscore('194910290TRI')
df = bs.dataframe
```

This was because the information that would have been required for all of these operations were valued None. While the decorators handle this issue for the particular values, the `TypeError` would happen with the arithmetic operators. 

This assumes that the attributes will only be of the correct type (float or int) or NoneType. 

This should also be done for the other classes. It appears that this will be a problem for very old games. For reference, this was the first NBA basketball game available on basketball reference. 

Happy to discuss this further or perhaps consider other ways to handle this. Also will be happy to do this for the other classes as I get to them. 
