### PR TITLE
Remove attempted_passes from NCAAF

### DIFF
--- a/sportsreference/ncaaf/player.py
+++ b/sportsreference/ncaaf/player.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import re
-import warnings
 from functools import wraps
 from lxml.etree import ParserError, XMLSyntaxError
 from pyquery import PyQuery as pq
@@ -211,17 +210,6 @@ class AbstractPlayer:
         Returns an ``int`` of the number of completed passes the player threw.
         """
         return self._completed_passes
-
-    @_int_property_decorator
-    def attempted_passes(self):
-        """
-        Returns an ``int`` of the number of passes the player attempted.
-        """
-        warnings.warn('Warning: "attempted_passes" is deprecated and will '
-                      'be removed in a future release. Please use '
-                      '"pass_attempts" instead for identical functionality.',
-                      DeprecationWarning)
-        return self._pass_attempts
 
     @_int_property_decorator
     def pass_attempts(self):

--- a/sportsreference/ncaaf/roster.py
+++ b/sportsreference/ncaaf/roster.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import re
-import warnings
 from functools import wraps
 from lxml.etree import ParserError, XMLSyntaxError
 from pyquery import PyQuery as pq
@@ -523,17 +522,6 @@ class Player(AbstractPlayer):
         Returns an ``int`` of the number of completed passes the player threw.
         """
         return self._completed_passes
-
-    @_int_property_decorator
-    def attempted_passes(self):
-        """
-        Returns an ``int`` of the number of passes the player attempted.
-        """
-        warnings.warn('Warning: "attempted_passes" is deprecated and will '
-                      'be removed in a future release. Please use '
-                      '"pass_attempts" instead for identical functionality.',
-                      DeprecationWarning)
-        return self._pass_attempts
 
     @_int_property_decorator
     def pass_attempts(self):

--- a/tests/unit/test_ncaaf_boxscore.py
+++ b/tests/unit/test_ncaaf_boxscore.py
@@ -435,22 +435,6 @@ Logos via Sports Logos.net / About logos
 
         assert self.boxscore.away_rush_attempts is None
 
-    @patch('requests.get', side_effect=mock_pyquery)
-    def test_attempted_passes_has_deprecation_warning(self, *args, **kwargs):
-        flexmock(AbstractPlayer) \
-            .should_receive('__init__') \
-            .and_return(None)
-        mock_passes = PropertyMock(return_value=[32])
-        mock_index = PropertyMock(return_value=0)
-        player = AbstractPlayer(None, None, None)
-        type(player)._pass_attempts = mock_passes
-        type(player)._index = mock_index
-
-        with pytest.deprecated_call():
-            result = player.attempted_passes
-
-            assert result == 32
-
 
 class TestNCAABBoxscores:
     @patch('requests.get', side_effect=mock_pyquery)

--- a/tests/unit/test_ncaaf_roster.py
+++ b/tests/unit/test_ncaaf_roster.py
@@ -49,16 +49,3 @@ class TestNCAAFPlayer:
         result = player.weight
 
         assert result is None
-
-    @patch('requests.get', side_effect=mock_pyquery)
-    def test_attempted_passes_has_deprecation_warning(self, *args, **kwargs):
-        mock_passes = PropertyMock(return_value=[32])
-        mock_index = PropertyMock(return_value=0)
-        player = Player(None)
-        type(player)._pass_attempts = mock_passes
-        type(player)._index = mock_index
-
-        with pytest.deprecated_call():
-            result = player.attempted_passes
-
-            assert result == 32


### PR DESCRIPTION
The NCAAF module has deprecated the `attempted_passes` property in favor of `pass_attempts` to be more consistent with other modules as well as the naming convention already present in NCAAF.

Fixes #171

Signed-Off-By: Robert Clark <robdclark@outlook.com>