### PR TITLE
Use tokenless Codecov action

### DIFF
--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -29,9 +29,7 @@ jobs:
         pycodestyle sportsreference/ tests/integration/ tests/unit/
     - name: Upload coverage to Codecov
       if: matrix.operating-system == 'ubuntu-latest' && matrix.python-version == '3.7'
-      uses: codecov/codecov-action@v1.0.2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v1.0.6
 
   publish:
     name: Publish package to PyPI


### PR DESCRIPTION
The original version of Codecov used in the repository required a token for proper authentication, which worked fine for all non-fork updates to the repository as the GitHub action secret was saved and usable. For all forked updates, however, the secret was not saved, and all actions would
fail as Codecov would try and push the coverage report without a token.

With the latest release of Codecov action v1.0.6, tokenless pushing is now available which solves the problem of pushing from forked repositories.

Signed-Off-By: Robert Clark <robdclark@outlook.com>