### PR TITLE
Add datetime property to NFL boxscores

### DIFF
--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import re
-from datetime import timedelta
+from datetime import datetime
 from pyquery import PyQuery as pq
 from urllib.error import HTTPError
 from .. import utils
@@ -732,6 +732,7 @@ class Boxscore:
             'away_yards_from_penalties': self.away_yards_from_penalties,
             'away_yards_lost_from_sacks': self.away_yards_lost_from_sacks,
             'date': self.date,
+            'datetime': self.datetime,
             'duration': self.duration,
             'home_first_downs': self.home_first_downs,
             'home_fourth_down_attempts': self.home_fourth_down_attempts,
@@ -814,6 +815,19 @@ class Boxscore:
         Returns a ``string`` of the time the game started.
         """
         return self._time
+
+    @property
+    def datetime(self):
+        """
+        Returns a ``datetime`` object of the date and time the game took place.
+        """
+        dt = None
+        if self._date and self._time:
+            date = '%s %s' % (self._date, self._time)
+            dt = datetime.strptime(date, '%A %b %d, %Y %I:%M%p')
+        elif self._date:
+            dt = datetime.strptime(self._date, '%A %b %d, %Y')
+        return dt
 
     @property
     def stadium(self):

--- a/tests/integration/boxscore/test_nfl_boxscore.py
+++ b/tests/integration/boxscore/test_nfl_boxscore.py
@@ -47,6 +47,7 @@ class TestNFLBoxscore:
         self.results = {
             'date': 'Sunday Feb 4, 2018',
             'time': '6:30pm',
+            'datetime': datetime(2018, 2, 4, 18, 30),
             'stadium': 'U.S. Bank Stadium',
             'attendance': 67612,
             'duration': '3:46',

--- a/tests/unit/test_nfl_boxscore.py
+++ b/tests/unit/test_nfl_boxscore.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from flexmock import flexmock
 from mock import patch, PropertyMock
 from pyquery import PyQuery as pq
@@ -284,6 +285,14 @@ itemprop="name">New England Patriots</a>')
         type(self.boxscore)._home_name = home_name
 
         assert self.boxscore.home_abbreviation == 'nwe'
+
+    def test_nfl_datetime_missing_time(self):
+        date = PropertyMock(return_value='Sunday Oct 7, 2018')
+        time = PropertyMock(return_value=None)
+        type(self.boxscore)._date = date
+        type(self.boxscore)._time = time
+
+        assert self.boxscore.datetime == datetime(2018, 10, 7)
 
 
 class TestNFLBoxscores:


### PR DESCRIPTION
The NFL boxscores class needs a datetime property comprised of both the date and time of the game to allow easier referencing of games in a schedule.

Fixes #384

Signed-Off-By: Robert Clark <robdclark@outlook.com>