### PR TITLE
Handle missing player weights throwing errors

### DIFF
--- a/sportsreference/mlb/roster.py
+++ b/sportsreference/mlb/roster.py
@@ -746,6 +746,8 @@ class Player(AbstractPlayer):
         """
         Returns an ``int`` of the player's weight in pounds.
         """
+        if not self._weight:
+            return None
         return int(self._weight.replace('lb', ''))
 
     @property

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -720,6 +720,8 @@ class Player(AbstractPlayer):
         """
         Returns an ``int`` of the player's weight in pounds.
         """
+        if not self._weight:
+            return None
         return int(self._weight.replace('lb', ''))
 
     @property

--- a/sportsreference/nfl/roster.py
+++ b/sportsreference/nfl/roster.py
@@ -663,6 +663,8 @@ class Player(AbstractPlayer):
         """
         Returns an ``int`` of the player's weight in pounds.
         """
+        if not self._weight:
+            return None
         return int(self._weight.replace('lb', ''))
 
     @property

--- a/sportsreference/nhl/roster.py
+++ b/sportsreference/nhl/roster.py
@@ -568,6 +568,8 @@ class Player(AbstractPlayer):
         """
         Returns an ``int`` of the player's weight in pounds.
         """
+        if not self._weight:
+            return None
         return int(self._weight.replace('lb', ''))
 
     @_int_property_decorator

--- a/tests/unit/test_mlb_roster.py
+++ b/tests/unit/test_mlb_roster.py
@@ -84,3 +84,11 @@ class TestMLBPlayer:
         result = _cleanup_player(None)
 
         assert result == ''
+
+    @patch('requests.get', side_effect=mock_pyquery)
+    def test_missing_weight_returns_none(self, *args, **kwargs):
+        mock_weight = PropertyMock(return_value=None)
+        player = Player(None)
+        type(player)._weight = mock_weight
+
+        assert not player.weight

--- a/tests/unit/test_nba_roster.py
+++ b/tests/unit/test_nba_roster.py
@@ -103,6 +103,14 @@ class TestNBAPlayer:
 
         assert player._contract is None
 
+    @patch('requests.get', side_effect=mock_pyquery)
+    def test_missing_weight_returns_none(self, *args, **kwargs):
+        mock_weight = PropertyMock(return_value=None)
+        player = Player(None)
+        type(player)._weight = mock_weight
+
+        assert not player.weight
+
 
 class TestInvalidNBAPlayer:
     def test_no_player_data_returns_no_stats(self):

--- a/tests/unit/test_nfl_roster.py
+++ b/tests/unit/test_nfl_roster.py
@@ -38,3 +38,11 @@ class TestNFLPlayer:
         result = player._retrieve_html_page()
 
         assert result is None
+
+    @patch('requests.get', side_effect=mock_pyquery)
+    def test_missing_weight_returns_none(self, *args, **kwargs):
+        mock_weight = PropertyMock(return_value=None)
+        player = Player(None)
+        type(player)._weight = mock_weight
+
+        assert not player.weight

--- a/tests/unit/test_nhl_roster.py
+++ b/tests/unit/test_nhl_roster.py
@@ -38,3 +38,11 @@ class TestNHLPlayer:
         result = player._retrieve_html_page()
 
         assert result is None
+
+    @patch('requests.get', side_effect=mock_pyquery)
+    def test_missing_weight_returns_none(self, *args, **kwargs):
+        mock_weight = PropertyMock(return_value=None)
+        player = Player(None)
+        type(player)._weight = mock_weight
+
+        assert not player.weight


### PR DESCRIPTION
If a player doesn't have a weight listed on his/her page, an `AttributeError` will be thrown while trying to call `replace` on an object of `None`. Simply checking if the weight is valid prior to attempting to replace the unit will prevent this error.

Fixes #393 

Signed-Off-By: Robert Clark <robdclark@outlook.com>