### PR TITLE
Enable NCAAF Team to be directly accessible

### DIFF
--- a/docs/ncaaf.rst
+++ b/docs/ncaaf.rst
@@ -247,6 +247,17 @@ number of pass yards, and much more.
         print(team.name)  # Prints the team's name
         print(team.pass_yards)  # Prints the team's total passing yards
 
+A team can also be requested directly by calling the ``Team`` class which
+returns a Team instance identical to the one in each element in the loop above.
+To request a specific team, use the team's abbreviation while calling the Team
+class.
+
+.. code-block:: python
+
+    from sportsreference.ncaaf.teams import Team
+
+    purdue = Team('PURDUE')
+
 Each Team instance contains a link to the ``Schedule`` class which enables easy
 iteration over all games for a particular team. A Pandas DataFrame can also be
 queried to easily grab all stats for all games.

--- a/sportsreference/ncaaf/ncaaf_utils.py
+++ b/sportsreference/ncaaf/ncaaf_utils.py
@@ -1,0 +1,91 @@
+from pyquery import PyQuery as pq
+from sportsreference import utils
+from .constants import (DEFENSIVE_STATS_URL,
+                        OFFENSIVE_STATS_URL,
+                        PARSING_SCHEME,
+                        SEASON_PAGE_URL)
+
+
+def _add_stats_data(teams_list, team_data_dict):
+    """
+    Add a team's stats row to a dictionary.
+
+    Pass table contents and a stats dictionary of all teams to accumulate all
+    stats for each team in a single variable.
+
+    Parameters
+    ----------
+    teams_list : generator
+        A generator of all row items in a given table.
+    team_data_dict : {str: {'data': str}} dictionary
+        A dictionary where every key is the team's abbreviation and every value
+        is another dictionary with a 'data' key which contains the string
+        version of the row data for the matched team.
+
+    Returns
+    -------
+    dictionary
+        An updated version of the team_data_dict with the passed table row
+        information included.
+    """
+    if not teams_list:
+        return team_data_dict
+    for team_data in teams_list:
+        # Skip the sub-header rows
+        if 'class="over_header thead"' in str(team_data) or \
+           'class="thead"' in str(team_data):
+            continue
+        abbr = utils._parse_field(PARSING_SCHEME, team_data, 'abbreviation')
+        try:
+            team_data_dict[abbr]['data'] += team_data
+        except KeyError:
+            team_data_dict[abbr] = {'data': team_data}
+    return team_data_dict
+
+
+def _retrieve_all_teams(year):
+    """
+    Find and create Team instances for all teams in the given season.
+
+    For a given season, parses the specified NCAAF stats table and finds
+    all requested stats. Each team then has a Team instance created which
+    includes all requested stats and a few identifiers, such as the team's
+    name and abbreviation. All of the individual Team instances are added
+    to a list.
+
+    Note that this method is called directly once Teams is invoked and does
+    not need to be called manually.
+
+    Parameters
+    ----------
+    year : string
+        The requested year to pull stats from.
+
+    Returns
+    -------
+    tuple
+        Returns a ``tuple`` of the team_data_dict and year which represent all
+        stats for all teams, and the given year that should be used to pull
+        stats from, respectively.
+    """
+    team_data_dict = {}
+
+    if not year:
+        year = utils._find_year_for_season('ncaaf')
+        # If stats for the requested season do not exist yet (as is the case
+        # right before a new season begins), attempt to pull the previous
+        # year's stats. If it exists, use the previous year instead.
+        if not utils._url_exists(SEASON_PAGE_URL % year) and \
+           utils._url_exists(SEASON_PAGE_URL % str(int(year) - 1)):
+            year = str(int(year) - 1)
+    doc = pq(SEASON_PAGE_URL % year)
+    teams_list = utils._get_stats_table(doc, 'div#div_standings')
+    offense_doc = pq(OFFENSIVE_STATS_URL % year)
+    offense_list = utils._get_stats_table(offense_doc, 'table#offense')
+    defense_doc = pq(DEFENSIVE_STATS_URL % year)
+    defense_list = utils._get_stats_table(defense_doc, 'table#defense')
+    if not teams_list and not offense_list and not defense_list:
+        utils._no_data_found()
+    for stats_list in [teams_list, offense_list, defense_list]:
+        team_data_dict = _add_stats_data(stats_list, team_data_dict)
+    return team_data_dict, year

--- a/tests/integration/roster/test_ncaaf_roster.py
+++ b/tests/integration/roster/test_ncaaf_roster.py
@@ -515,7 +515,7 @@ class TestNCAAFRoster:
         flexmock(Team) \
             .should_receive('_parse_team_data') \
             .and_return(None)
-        team = Team(None, 1, '2018')
+        team = Team(team_data=None, team_conference=None, year='2018')
         mock_abbreviation = mock.PropertyMock(return_value='PURDUE')
         type(team)._abbreviation = mock_abbreviation
 

--- a/tests/integration/teams/test_ncaaf_integration.py
+++ b/tests/integration/teams/test_ncaaf_integration.py
@@ -8,7 +8,7 @@ from sportsreference.ncaaf.conferences import Conferences
 from sportsreference.ncaaf.constants import (OFFENSIVE_STATS_URL,
                                              DEFENSIVE_STATS_URL,
                                              SEASON_PAGE_URL)
-from sportsreference.ncaaf.teams import Teams
+from sportsreference.ncaaf.teams import Team, Teams
 
 
 MONTH = 9
@@ -357,6 +357,13 @@ class TestNCAAFIntegration:
         teams = Teams()
 
         assert len(teams) == 0
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_pulling_team_directly(self, *args, **kwargs):
+        purdue = Team('PURDUE')
+
+        for attribute, value in self.results.items():
+            assert getattr(purdue, attribute) == value
 
 
 class TestNCAAFIntegrationInvalidYear:


### PR DESCRIPTION
Instead of requiring users to go through the Teams class to get a specific team, the NCAAF modules now enable a specific team to be directly queried by using the Team class. This reduces computational complexity by removing the need to instantiate every team while also
making it more intuitive for users.

Related to #360

Signed-Off-By: Robert Clark <robdclark@outlook.com>