### PR TITLE
Enable NHL Team to be directly accessible

### DIFF
--- a/docs/nhl.rst
+++ b/docs/nhl.rst
@@ -180,6 +180,17 @@ number of shots on goal, and much more.
         print(team.name)  # Prints the team's name
         print(team.shots_on_goal)  # Prints the team's total shots on goal
 
+A team can also be requested directly by calling the ``Team`` class which
+returns a Team instance identical to the one in each element in the loop above.
+To request a specific team, use the 3-letter abbreviation for the team while
+calling Team class.
+
+.. code-block:: python
+
+    from sportsreference.nhl.teams import Team
+
+    detroit = Team('DET')
+
 Each Team instance contains a link to the ``Schedule`` class which enables easy
 iteration over all games for a particular team. A Pandas DataFrame can also be
 queried to easily grab all stats for all games.

--- a/sportsreference/nhl/nhl_utils.py
+++ b/sportsreference/nhl/nhl_utils.py
@@ -1,0 +1,43 @@
+from pyquery import PyQuery as pq
+from sportsreference import utils
+from .constants import SEASON_PAGE_URL
+
+
+def _retrieve_all_teams(year):
+    """
+    Find and create Team instances for all teams in the given season.
+
+    For a given season, parses the specified NHL stats table and finds all
+    requested stats. Each team then has a Team instance created which includes
+    all requested stats and a few identifiers, such as the team's name and
+    abbreviation. All of the individual Team instances are added to a list.
+
+    Note that this method is called directly once Teams is invoked and does not
+    need to be called manually.
+
+    Parameters
+    ----------
+    year : string
+        The requested year to pull stats from.
+
+    Returns
+    -------
+    tuple
+        Returns a ``tuple`` in the format of (teams_list, year) where the
+        teams_list is the PyQuery data for every team in the given season, and
+        the year is the request year for the season.
+    """
+    if not year:
+        year = utils._find_year_for_season('nhl')
+        # If stats for the requested season do not exist yet (as is the case
+        # right before a new season begins), attempt to pull the previous
+        # year's stats. If it exists, use the previous year instead.
+        if not utils._url_exists(SEASON_PAGE_URL % year) and \
+           utils._url_exists(SEASON_PAGE_URL % str(int(year) - 1)):
+            year = str(int(year) - 1)
+    doc = pq(SEASON_PAGE_URL % year)
+    teams_list = utils._get_stats_table(doc, 'div#all_stats')
+    if not teams_list:
+        utils._no_data_found()
+        return None, None
+    return teams_list, year

--- a/tests/integration/roster/test_nhl_roster.py
+++ b/tests/integration/roster/test_nhl_roster.py
@@ -700,7 +700,7 @@ class TestNHLRoster:
         flexmock(Team) \
             .should_receive('_parse_team_data') \
             .and_return(None)
-        team = Team(None, 1, '2018')
+        team = Team(team_data=None, rank=1, year='2018')
         mock_abbreviation = mock.PropertyMock(return_value='DET')
         type(team)._abbreviation = mock_abbreviation
 

--- a/tests/integration/teams/test_nhl_integration.py
+++ b/tests/integration/teams/test_nhl_integration.py
@@ -5,7 +5,7 @@ import pytest
 from flexmock import flexmock
 from sportsreference import utils
 from sportsreference.nhl.constants import SEASON_PAGE_URL
-from sportsreference.nhl.teams import Teams
+from sportsreference.nhl.teams import Team, Teams
 
 
 MONTH = 1
@@ -146,6 +146,13 @@ class TestNHLIntegration:
         teams = Teams()
 
         assert len(teams) == 0
+
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_pulling_team_directly(self, *args, **kwargs):
+        detroit = Team('DET')
+
+        for attribute, value in self.results.items():
+            assert getattr(detroit, attribute) == value
 
 
 class TestNHLIntegrationInvalidYear:


### PR DESCRIPTION
Instead of requiring users to go through the Teams class to get a specific team, the NHL modules now enable a specific team to be directly queried by using the Team class. This reduces computational complexity by removing the need to instantiate every team while also making it more intuitive for users.

Related to #360

Signed-Off-By: Robert Clark <robdclark@outlook.com>