### PR TITLE
Fix issue with FB schedule using invalid date

### DIFF
--- a/tests/integration/schedule/test_fb_schedule.py
+++ b/tests/integration/schedule/test_fb_schedule.py
@@ -76,7 +76,7 @@ class TestFBSchedule:
 
     def test_no_games_for_date_raises_value_error(self):
         with pytest.raises(ValueError):
-            self.schedule(datetime.now())
+            self.schedule(datetime(2020, 7, 1))
 
     def test_empty_page_return_no_games(self):
         flexmock(utils) \


### PR DESCRIPTION
Using the current datetime could run into an issue for the football schedule tests if the date a test was run happened to be an actual date on the team's schedule would fail to throw a `ValueError`. Instead, a date that is known to not be on the team's schedule should be used to ensure
the tests can complete regardless of the date run.

Fixes #408 

Signed-Off-By: Robert Clark <robdclark@outlook.com>