### PR TITLE
Added coach to Roster

### DIFF
--- a/sportsreference/mlb/roster.py
+++ b/sportsreference/mlb/roster.py
@@ -1438,12 +1438,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self.coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def _pull_team_page(self, url):
         """
@@ -1529,7 +1530,7 @@ class Roster:
         name_tag = player('td[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1587,6 +1588,12 @@ class Roster:
             else:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
+
+        for p in page('*[data-template="Partials/Teams/Summary"]').find('p'):
+            s = p.find('strong')
+            if hasattr(s, 'text'):
+                if s.text == 'Manager: ':
+                    self.coach = p.find('a').text
 
     @property
     def players(self):

--- a/sportsreference/nba/nba_utils.py
+++ b/sportsreference/nba/nba_utils.py
@@ -72,6 +72,7 @@ def _retrieve_all_teams(year):
     doc = pq(SEASON_PAGE_URL % year)
     teams_list = utils._get_stats_table(doc, 'div#all_team-stats-base')
     opp_teams_list = utils._get_stats_table(doc, 'div#all_opponent-stats-base')
+
     if not teams_list and not opp_teams_list:
         utils._no_data_found()
         return None, None

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -1352,5 +1352,3 @@ class Roster:
         first and last name as listed on the roster page.
         """
         return self._players
-
-

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -1206,7 +1206,8 @@ class Roster:
         else:
             self._players = []
 
-        self._find_players(year)
+        self.coach = None
+        self._find_players_with_coach(year)
 
     def _pull_team_page(self, url):
         """
@@ -1292,7 +1293,7 @@ class Roster:
         name_tag = player('td[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1335,6 +1336,12 @@ class Roster:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
 
+        for p in page('*[data-template="Partials/Teams/Summary"]').find('p'):
+            s = p.find('strong')
+            if hasattr(s, 'text'):
+                if s.text == 'Coach:':
+                    self.coach = p.find('a').text
+
     @property
     def players(self):
         """
@@ -1345,3 +1352,5 @@ class Roster:
         first and last name as listed on the roster page.
         """
         return self._players
+
+

--- a/sportsreference/nba/teams.py
+++ b/sportsreference/nba/teams.py
@@ -723,5 +723,6 @@ class Teams:
             frames.append(team.dataframe)
         return pd.concat(frames)
 
+
 if __name__ == '__main__':
     tm = Teams()

--- a/sportsreference/nba/teams.py
+++ b/sportsreference/nba/teams.py
@@ -86,6 +86,7 @@ class Team:
 
         if team_name:
             team_data = self._retrieve_team_data(year, team_name)
+
         self._parse_team_data(team_data)
 
     def _retrieve_team_data(self, year, team_name):
@@ -721,3 +722,6 @@ class Teams:
         for team in self.__iter__():
             frames.append(team.dataframe)
         return pd.concat(frames)
+
+if __name__ == '__main__':
+    tm = Teams()

--- a/sportsreference/nba/teams.py
+++ b/sportsreference/nba/teams.py
@@ -722,7 +722,3 @@ class Teams:
         for team in self.__iter__():
             frames.append(team.dataframe)
         return pd.concat(frames)
-
-
-if __name__ == '__main__':
-    tm = Teams()

--- a/sportsreference/ncaab/roster.py
+++ b/sportsreference/ncaab/roster.py
@@ -644,12 +644,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self.coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def _pull_team_page(self, url):
         """
@@ -735,7 +736,7 @@ class Roster:
         name_tag = player('th[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -775,6 +776,12 @@ class Roster:
             else:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
+
+        for p in page('*[data-template="Partials/Teams/Summary"]').find('p'):
+            s = p.find('strong')
+            if hasattr(s, 'text'):
+                if s.text == 'Coach:':
+                    self.coach = p.find('a').text
 
     @property
     def players(self):

--- a/sportsreference/ncaaf/roster.py
+++ b/sportsreference/ncaaf/roster.py
@@ -871,12 +871,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self.coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def _pull_team_page(self, url):
         """
@@ -962,7 +963,7 @@ class Roster:
         name_tag = player('th[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1001,6 +1002,12 @@ class Roster:
             else:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
+
+        for p in page('*[data-template="Partials/Teams/Summary"]').find('p'):
+            s = p.find('strong')
+            if hasattr(s, 'text'):
+                if s.text == 'Coach:':
+                    self.coach = p.find('a').text
 
     @property
     def players(self):

--- a/sportsreference/nfl/roster.py
+++ b/sportsreference/nfl/roster.py
@@ -1495,12 +1495,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self.coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def _pull_team_page(self, url):
         """
@@ -1586,7 +1587,7 @@ class Roster:
         name_tag = player('td[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1625,6 +1626,12 @@ class Roster:
             else:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
+
+        for p in page('*[data-template="Partials/Teams/Summary"]').find('p'):
+            s = p.find('strong')
+            if hasattr(s, 'text'):
+                if s.text == 'Coach:':
+                    self.coach = p.find('a').text
 
     @property
     def players(self):

--- a/sportsreference/nhl/roster.py
+++ b/sportsreference/nhl/roster.py
@@ -1093,12 +1093,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self.coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def _pull_team_page(self, url):
         """
@@ -1182,7 +1183,7 @@ class Roster:
         name_tag = player('td[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1221,6 +1222,11 @@ class Roster:
             else:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
+
+        for p in page('*[data-template="Partials/Teams/Summary"]').find('p'):
+            s = p.find('strong')
+            if s.text == 'Coach:':
+                self.coach = p.find('a').text
 
     @property
     def players(self):

--- a/tests/integration/roster/test_mlb_roster.py
+++ b/tests/integration/roster/test_mlb_roster.py
@@ -1232,3 +1232,6 @@ class TestMLBRoster:
         for player in roster.players:
             assert player.name in [u'José Altuve', 'Justin Verlander',
                                    'Charlie Morton']
+
+    def test_coach(self):
+        assert "AJ Hinch" == Roster('HOU', year=YEAR).coach

--- a/tests/integration/roster/test_nba_roster.py
+++ b/tests/integration/roster/test_nba_roster.py
@@ -1272,3 +1272,6 @@ class TestNBARoster:
         roster = Roster('HOU')
 
         assert len(roster.players) == 0
+
+    def test_coach(self):
+        assert "Mike D'Antoni" == Roster('HOU').coach

--- a/tests/integration/roster/test_ncaab_roster.py
+++ b/tests/integration/roster/test_ncaab_roster.py
@@ -426,3 +426,6 @@ class TestNCAABRoster:
         for player in roster.players:
             assert player.name in ['Carsen Edwards', 'Isaac Haas',
                                    'Vince Edwards']
+
+    def test_coach(self):
+        assert "Matt Painter" == Roster('PURDUE', year=YEAR).coach

--- a/tests/integration/roster/test_ncaaf_roster.py
+++ b/tests/integration/roster/test_ncaaf_roster.py
@@ -552,3 +552,6 @@ class TestNCAAFRoster:
         assert len(roster.players) == 2
         for player in roster.players:
             assert player.name in ['David Blough', 'Rondale Moore']
+
+    def test_coach(self):
+        assert "Troy Calhoun" == Roster('air-force', year=YEAR).coach

--- a/tests/integration/roster/test_nfl_roster.py
+++ b/tests/integration/roster/test_nfl_roster.py
@@ -1241,3 +1241,6 @@ class TestNFLRoster:
             assert player.name in ['Drew Brees', 'Demario Davis',
                                    'Tommylee Lewis', 'Wil Lutz',
                                    'Thomas Morstead']
+
+    def test_coach(self):
+        assert "Sean Payton" == Roster('NOR', year=YEAR).coach

--- a/tests/integration/roster/test_nhl_roster.py
+++ b/tests/integration/roster/test_nhl_roster.py
@@ -738,3 +738,6 @@ class TestNHLRoster:
 
         for player in roster.players:
             assert player.name in ['Jimmy Howard', 'Henrik Zetterberg']
+
+    def test_coach(self):
+        assert "Jeff Blashill" == Roster('DET', year=YEAR).coach


### PR DESCRIPTION
I've added coach field to Roster class. I think it's good place to put it there because information about coach is in the same page as roster.

Usage:
```
from sportsreference.nba.teams import Team
detroit = Team("DET")
detroit_roster = detroit.roster
detroit_coach = detroit_roster.coach
```

I hope it would resolve #285 