### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -13,7 +13,7 @@ jobs:
       # Prevent the entire workflow from failing if a singular test fails.
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         operating-system: [ubuntu-latest, macOS-latest, windows-latest]
         sport: ['FB', 'MLB', 'NBA', 'NCAAB', 'NCAAF', 'NFL', 'NHL']
 

--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         operating-system: [ubuntu-latest, macOS-latest, windows-latest, windows-2016]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='MIT',
     url='https://github.com/roclark/sportsreference',
     packages=find_packages(),
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     keywords='stats sports api sportsreference machine learning',
     install_requires=[
         "pandas >= 0.24.1",
@@ -24,7 +24,6 @@ setup(
         "requests >= 2.18.4"
     ],
     classifiers=(
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
With Python 3.5 reaching its end-of-life date on September 13, 2020, sportsreference should officially drop support for Python 3.5 to encourage users to migrate to a newer version of Python that remain supported in the future. Only issues for Python 2.7 that pose serious security risks will be fixed in the future and only on a case-by-case basis.

Fixes #372

Signed-Off-By: Robert Clark <robdclark@outlook.com>