### PR TITLE
Update Codecov to latest version

### DIFF
--- a/.github/workflows/pushtests.yml
+++ b/.github/workflows/pushtests.yml
@@ -28,8 +28,8 @@ jobs:
       run: |
         pycodestyle sportsreference/ tests/integration/ tests/unit/
     - name: Upload coverage to Codecov
-      if: matrix.operating-system == 'ubuntu-latest' && matrix.python-version == '3.7'
-      uses: codecov/codecov-action@v1.0.6
+      if: matrix.operating-system == 'ubuntu-latest' && matrix.python-version == '3.8'
+      uses: codecov/codecov-action@v1.0.13
 
   publish:
     name: Publish package to PyPI


### PR DESCRIPTION
The previous version of Codecov in the Actions was not authenticating properly with the Codecov servers, preventing the coverage diffs from being displayed in PRs. By updating to the latest versions of Python and Codecov, the coverage reports will now be displayed on PR.

Fixes #473

Signed-Off-By: Robert Clark <robdclark@outlook.com>