### PR TITLE
Fix issues pulling default NBA year for 2020

### DIFF
--- a/sportsreference/nba/nba_utils.py
+++ b/sportsreference/nba/nba_utils.py
@@ -1,6 +1,7 @@
 from .constants import PARSING_SCHEME, SEASON_PAGE_URL
 from pyquery import PyQuery as pq
 from sportsreference import utils
+from urllib.error import HTTPError
 
 
 def _add_stats_data(teams_list, team_data_dict):
@@ -63,6 +64,15 @@ def _retrieve_all_teams(year):
 
     if not year:
         year = utils._find_year_for_season('nba')
+        # Given the delays to the NBA season in 2020, the default season
+        # selection logic is no longer valid after the original season should
+        # have concluded. In this case, the previous season should be pulled
+        # instead.
+        if year == 2021:
+            try:
+                doc = pq(SEASON_PAGE_URL % year)
+            except HTTPError:
+                year = str(int(year) - 1)
         # If stats for the requested season do not exist yet (as is the case
         # right before a new season begins), attempt to pull the previous
         # year's stats. If it exists, use the previous year instead.

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -1507,6 +1507,15 @@ class Roster:
         """
         if not year:
             year = utils._find_year_for_season('nba')
+            # Given the delays to the NBA season in 2020, the default season
+            # selection logic is no longer valid after the original season
+            # should have concluded. In this case, the previous season should
+            # be pulled instead.
+            if year == 2021:
+                try:
+                    doc = pq(self._create_url(year))
+                except HTTPError:
+                    year = str(int(year) - 1)
             # If stats for the requested season do not exist yet (as is the
             # case right before a new season begins), attempt to pull the
             # previous year's stats. If it exists, use the previous year

--- a/sportsreference/nba/schedule.py
+++ b/sportsreference/nba/schedule.py
@@ -14,6 +14,7 @@ from sportsreference.constants import (WIN,
                                        REGULAR_SEASON,
                                        CONFERENCE_TOURNAMENT)
 from sportsreference.nba.boxscore import Boxscore
+from urllib.error import HTTPError
 
 
 class Game:
@@ -428,6 +429,15 @@ class Schedule:
         """
         if not year:
             year = utils._find_year_for_season('nba')
+            # Given the delays to the NBA season in 2020, the default season
+            # selection logic is no longer valid after the original season
+            # should have concluded. In this case, the previous season should
+            # be pulled instead.
+            if year == 2021:
+                try:
+                    doc = pq(SCHEDULE_URL % (abbreviation.lower(), year))
+                except HTTPError:
+                    year = str(int(year) - 1)
             # If stats for the requested season do not exist yet (as is the
             # case right before a new season begins), attempt to pull the
             # previous year's stats. If it exists, use the previous year

--- a/tests/unit/test_nba_utils.py
+++ b/tests/unit/test_nba_utils.py
@@ -1,0 +1,36 @@
+import mock
+from flexmock import flexmock
+from sportsreference import utils
+from sportsreference.nba.nba_utils import _retrieve_all_teams
+
+
+def mock_pyquery(url):
+    class MockPQ:
+        def __init__(self, html_contents, status_code=200):
+            self.status_code = status_code
+            self.html_contents = html_contents
+            self.text = html_contents
+            self.url = url
+            self.reason = 'Invalid'
+            self.headers = {}
+
+        def __call__(self, div):
+            return self.html_contents
+
+    if '2021' in url:
+        return MockPQ('<div/>', status_code=404)
+    else:
+        return MockPQ('<div id="all_team-stats-base"/>'
+                      '<div id="all_opponent-stats-base"/>')
+
+
+class TestNBAUtils:
+    @mock.patch('requests.get', side_effect=mock_pyquery)
+    def test_nba_2020_season_default_to_previous(self, *args, **kwargs):
+        flexmock(utils) \
+            .should_receive('_find_year_for_season') \
+            .and_return(2021)
+
+        _, year = _retrieve_all_teams(None)
+
+        assert year == '2020'


### PR DESCRIPTION
Given the lengthy delays to the NBA season in 2020, attempting to pull the NBA modules towards the end of the calendar year throws off the logic as the default logic assumes the next season is either getting ready to start or is already underway. In 2020, however, this has not yet happened, and an `HTTPError` will be thrown while attempting to pull the stats without specifying the year. By doing a one-off check for 2020, a handler can be made to identify whether or not the next season has started yet. This will only be applicable for the second half of 2020, and can be removed at a later date.

Fixes #464 

Signed-Off-By: Robert Clark <robdclark@outlook.com>