### PR TITLE
Replace invalid variable name in Boxscore modules

### DIFF
--- a/sportsreference/mlb/boxscore.py
+++ b/sportsreference/mlb/boxscore.py
@@ -1913,7 +1913,7 @@ class Boxscores:
                 home_score = details
             boxscore_url = game('td[class="right gamelink"] a')
             boxscore_uri = self._get_boxscore_uri(boxscore_url)
-            losers = [l for l in game('tr[class="loser"]').items()]
+            losers = [loser for loser in game('tr[class="loser"]').items()]
             winner = self._get_team_results(game('tr[class="winner"]'))
             loser = self._get_team_results(game('tr[class="loser"]'))
             # Occurs when the boxscore format is invalid and the game should be

--- a/sportsreference/nba/boxscore.py
+++ b/sportsreference/nba/boxscore.py
@@ -1819,7 +1819,7 @@ class Boxscores:
                 home_score = details
             boxscore_url = game('td[class="right gamelink"] a')
             boxscore_uri = self._get_boxscore_uri(boxscore_url)
-            losers = [l for l in game('tr[class="loser"]').items()]
+            losers = [loser for loser in game('tr[class="loser"]').items()]
             winner = self._get_team_results(game('tr[class="winner"]'))
             loser = self._get_team_results(game('tr[class="loser"]'))
             # Occurs when the boxscore format is invalid and the game should be

--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -1595,7 +1595,7 @@ class Boxscores:
                 home_score = details
             boxscore_url = game('td[class="right gamelink"] a')
             boxscore_uri = self._get_boxscore_uri(boxscore_url)
-            losers = [l for l in game('tr[class="loser"]').items()]
+            losers = [loser for loser in game('tr[class="loser"]').items()]
             winner = self._get_team_results(game('tr[class="winner"]'))
             loser = self._get_team_results(game('tr[class="loser"]'))
             # Occurs when the boxscore format is invalid and the game should be

--- a/sportsreference/nhl/boxscore.py
+++ b/sportsreference/nhl/boxscore.py
@@ -1393,7 +1393,7 @@ class Boxscores:
                 home_score = details
             boxscore_url = game('td[class="right gamelink"] a')
             boxscore_uri = self._get_boxscore_uri(boxscore_url)
-            losers = [l for l in game('tr[class="loser"]').items()]
+            losers = [loser for loser in game('tr[class="loser"]').items()]
             winner = self._get_team_results(game('tr[class="winner"]'))
             loser = self._get_team_results(game('tr[class="loser"]'))
             # Occurs when the boxscore format is invalid and the game should be


### PR DESCRIPTION
Newer versions of `pycodestyle` flag inadequate variable names, such as single letters, which should be replaced with more descriptive names.

Fixes #485

Signed-Off-By: Robert Clark <robdclark@outlook.com>