### PR TITLE
Allow local data files over downloading pages

### DIFF
--- a/sportsreference/fb/team.py
+++ b/sportsreference/fb/team.py
@@ -30,8 +30,12 @@ class Team:
         Hotspur', or the team's 8-digit squad ID, such as '361ca564' for
         Tottenham. If a team can't be found for the given name, a list of
         suggestions will be returned with corresponding squad IDs.
+    squad_page : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Squad page for the designated year.
     """
-    def __init__(self, team_id):
+    def __init__(self, team_id, squad_page=None):
         self._squad_id = None
         self._name = None
         self._season = None
@@ -62,7 +66,7 @@ class Team:
         self._away_points = None
 
         self._squad_id = _lookup_team(team_id)
-        self._pull_team_page()
+        self._pull_team_page(squad_page)
 
     def __str__(self):
         """
@@ -285,16 +289,23 @@ class Team:
             elif 'gender' in line.lower():
                 self._gender = line.replace('Gender: ', '')
 
-    def _pull_team_page(self):
+    def _pull_team_page(self, squad_page=None):
         """
         Pull the team page and parse results.
 
         Using the requested squad ID, first pull the team page, then parse
         the header for relevant information on the team including records,
         goals, manager, league results, and more.
+
+        Parameters
+        ----------
+        squad_page : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Squad page for the designated year.
         """
         try:
-            doc = pq(SQUAD_URL % self.squad_id)
+            doc = utils._pull_page(SQUAD_URL % self.squad_id, squad_page)
         except HTTPError:
             return
         self._doc = doc

--- a/sportsreference/mlb/mlb_utils.py
+++ b/sportsreference/mlb/mlb_utils.py
@@ -41,7 +41,7 @@ def _add_stats_data(teams_list, team_data_dict):
     return team_data_dict
 
 
-def _retrieve_all_teams(year):
+def _retrieve_all_teams(year, standings_file=None, teams_file=None):
     """
     Find and create Team instances for all teams in the given season.
 
@@ -54,6 +54,10 @@ def _retrieve_all_teams(year):
     ----------
     year : string
         The requested year to pull stats from.
+    standings_file : string (optional)
+        Link with filename to the local standings page.
+    teams_file : string (optional)
+        Link with filename to the local teams page.
 
     Returns
     -------
@@ -72,10 +76,10 @@ def _retrieve_all_teams(year):
         if not utils._url_exists(STANDINGS_URL % year) and \
            utils._url_exists(STANDINGS_URL % str(int(year) - 1)):
             year = str(int(year) - 1)
-    doc = pq(STANDINGS_URL % year)
+    doc = utils._pull_page(STANDINGS_URL % year, standings_file)
     div_prefix = 'div#all_expanded_standings_overall'
     standings = utils._get_stats_table(doc, div_prefix)
-    doc = pq(TEAM_STATS_URL % year)
+    doc = utils._pull_page(TEAM_STATS_URL % year, teams_file)
     div_prefix = 'div#all_teams_standard_%s'
     batting_stats = utils._get_stats_table(doc, div_prefix % 'batting')
     pitching_stats = utils._get_stats_table(doc, div_prefix % 'pitching')

--- a/sportsreference/mlb/teams.py
+++ b/sportsreference/mlb/teams.py
@@ -56,8 +56,17 @@ class Team:
         Teams class.
     year : string (optional)
         The requested year to pull stats from.
+    standings_file : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Standings page for the designated year.
+    teams_file : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the League page for the designated year.
     """
-    def __init__(self, team_name=None, team_data=None, rank=None, year=None):
+    def __init__(self, team_name=None, team_data=None, rank=None, year=None,
+                 standings_file=None, teams_file=None):
         self._year = year
         self._rank = rank
         self._abbreviation = None
@@ -142,7 +151,8 @@ class Team:
         self._opposing_runners_left_on_base = None
 
         if team_name:
-            team_data = self._retrieve_team_data(year, team_name)
+            team_data = self._retrieve_team_data(year, team_name,
+                                                 standings_file, teams_file)
 
         self._parse_team_data(team_data)
 
@@ -158,7 +168,8 @@ class Team:
         """
         return self.__str__()
 
-    def _retrieve_team_data(self, year, team_name):
+    def _retrieve_team_data(self, year, team_name, standings_file=None,
+                            teams_file=None):
         """
         Pull all stats for a specific team.
 
@@ -173,6 +184,14 @@ class Team:
         team_name : string
             A ``string`` of the team's 3-letter abbreviation, such as 'HOU' for
             the Houston Astros.
+        standings_file : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Standings page for the designated year.
+        teams_file : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the League page for the designated year.
 
         Returns
         -------
@@ -180,7 +199,8 @@ class Team:
             Returns a PyQuery object containing all stats and information for
             the specified team.
         """
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, standings_file,
+                                                   teams_file)
         self._year = year
         team_data = team_data_dict[team_name]['data']
         self._rank = team_data_dict[team_name]['rank']
@@ -1203,11 +1223,20 @@ class Teams:
     ----------
     year : string (optional)
         The requested year to pull stats from.
+    standings_file : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Standings page for the designated year.
+    teams_file : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the League page for the designated year.
     """
-    def __init__(self, year=None):
+    def __init__(self, year=None, standings_file=None, teams_file=None):
         self._teams = []
 
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, standings_file,
+                                                   teams_file)
         self._instantiate_teams(team_data_dict, year)
 
     def __str__(self):

--- a/sportsreference/nba/nba_utils.py
+++ b/sportsreference/nba/nba_utils.py
@@ -39,7 +39,7 @@ def _add_stats_data(teams_list, team_data_dict):
     return team_data_dict
 
 
-def _retrieve_all_teams(year):
+def _retrieve_all_teams(year, season_file=None):
     """
     Find and create Team instances for all teams in the given season.
 
@@ -52,6 +52,8 @@ def _retrieve_all_teams(year):
     ----------
     year : string
         The requested year to pull stats from.
+    season_file : string (optional)
+        Link with filename to the local season page.
 
     Returns
     -------
@@ -79,7 +81,7 @@ def _retrieve_all_teams(year):
         if not utils._url_exists(SEASON_PAGE_URL % year) and \
            utils._url_exists(SEASON_PAGE_URL % str(int(year) - 1)):
             year = str(int(year) - 1)
-    doc = pq(SEASON_PAGE_URL % year)
+    doc = utils._pull_page(SEASON_PAGE_URL % year, season_file)
     teams_list = utils._get_stats_table(doc, 'div#all_team-stats-base')
     opp_teams_list = utils._get_stats_table(doc, 'div#all_opponent-stats-base')
     if not teams_list and not opp_teams_list:

--- a/sportsreference/nba/teams.py
+++ b/sportsreference/nba/teams.py
@@ -33,8 +33,13 @@ class Team:
         Teams class.
     year : string (optional)
         The requested year to pull stats from.
+    season_file : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Season page for the designated year.
     """
-    def __init__(self, team_name=None, team_data=None, rank=None, year=None):
+    def __init__(self, team_name=None, team_data=None, rank=None, year=None,
+                 season_file=None):
         self._year = year
         self._rank = rank
         self._abbreviation = None
@@ -85,7 +90,7 @@ class Team:
         self._opp_points = None
 
         if team_name:
-            team_data = self._retrieve_team_data(year, team_name)
+            team_data = self._retrieve_team_data(year, team_name, season_file)
         self._parse_team_data(team_data)
 
     def __str__(self):
@@ -100,7 +105,7 @@ class Team:
         """
         return self.__str__()
 
-    def _retrieve_team_data(self, year, team_name):
+    def _retrieve_team_data(self, year, team_name, season_file=None):
         """
         Pull all stats for a specific team.
 
@@ -115,6 +120,10 @@ class Team:
         team_name : string
             A ``string`` of the team's 3-letter abbreviation, such as 'HOU' for
             the Houston Rockets.
+       season_file : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Season page for the designated year.
 
         Returns
         -------
@@ -122,7 +131,7 @@ class Team:
             Returns a PyQuery object containing all stats and information for
             the specified team.
         """
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, season_file)
         self._year = year
         team_data = team_data_dict[team_name]['data']
         self._rank = team_data_dict[team_name]['rank']
@@ -632,11 +641,15 @@ class Teams:
     ----------
     year : string (optional)
         The requested year to pull stats from.
+    season_file : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Season page for the designated year.
     """
-    def __init__(self, year=None):
+    def __init__(self, year=None, season_file=None):
         self._teams = []
 
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, season_file)
         self._instantiate_teams(team_data_dict, year)
 
     def __getitem__(self, abbreviation):

--- a/sportsreference/ncaab/ncaab_utils.py
+++ b/sportsreference/ncaab/ncaab_utils.py
@@ -41,7 +41,8 @@ def _add_stats_data(teams_list, team_data_dict):
     return team_data_dict
 
 
-def _retrieve_all_teams(year):
+def _retrieve_all_teams(year, basic_stats=None, basic_opp_stats=None,
+                        adv_stats=None, adv_opp_stats=None):
     """
     Find and create Team instances for all teams in the given season.
 
@@ -57,6 +58,14 @@ def _retrieve_all_teams(year):
     ----------
     year : string
         The requested year to pull stats from.
+    basic_stats : string (optional)
+        Link with filename to the local basic stats page.
+    basic_opp_stats : string (optional)
+        Link with filename to the local basic opponent stats page.
+    adv_stats : string (optional)
+        Link with filename to the local advanved stats page.
+    adv_opp_stats : string (optional)
+        Link with filename to the local advanced opponents stats page.
 
     Returns
     -------
@@ -75,13 +84,13 @@ def _retrieve_all_teams(year):
         if not utils._url_exists(BASIC_STATS_URL % year) and \
            utils._url_exists(BASIC_STATS_URL % str(int(year) - 1)):
             year = str(int(year) - 1)
-    doc = pq(BASIC_STATS_URL % year)
+    doc = utils._pull_page(BASIC_STATS_URL % year, basic_stats)
     teams_list = utils._get_stats_table(doc, 'table#basic_school_stats')
-    doc = pq(BASIC_OPPONENT_STATS_URL % year)
+    doc = utils._pull_page(BASIC_OPPONENT_STATS_URL % year, basic_opp_stats)
     opp_list = utils._get_stats_table(doc, 'table#basic_opp_stats')
-    doc = pq(ADVANCED_STATS_URL % year)
+    doc = utils._pull_page(ADVANCED_STATS_URL % year, adv_stats)
     adv_teams_list = utils._get_stats_table(doc, 'table#adv_school_stats')
-    doc = pq(ADVANCED_OPPONENT_STATS_URL % year)
+    doc = utils._pull_page(ADVANCED_OPPONENT_STATS_URL % year, adv_opp_stats)
     adv_opp_list = utils._get_stats_table(doc, 'table#adv_opp_stats')
     if not teams_list and not opp_list and not adv_teams_list \
        and not adv_opp_list:

--- a/sportsreference/ncaab/teams.py
+++ b/sportsreference/ncaab/teams.py
@@ -32,9 +32,26 @@ class Team:
         A string of the team's conference abbreviation, such as 'big-12'.
     year : string (optional)
         The requested year to pull stats from.
+    basic_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Basic Stats page for the designated year.
+    basic_opp_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Basic Opponent Stats page for the designated year.
+    adv_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Advanced Stats page for the designated year.
+    adv_opp_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Advanced Opponent Stats page for the designated year.
     """
     def __init__(self, team_name=None, team_data=None, team_conference=None,
-                 year=None):
+                 year=None, basic_stats=None, basic_opp_stats=None,
+                 adv_stats=None, adv_opp_stats=None):
         self._team_conference = team_conference
         self._year = year
         self._abbreviation = None
@@ -121,7 +138,9 @@ class Team:
         self._opp_free_throws_per_field_goal_attempt = None
 
         if team_name:
-            team_data = self._retrieve_team_data(year, team_name)
+            team_data = self._retrieve_team_data(year, team_name, basic_stats,
+                                                 basic_opp_stats, adv_stats,
+                                                 adv_opp_stats)
             conferences_dict = Conferences(year).team_conference
             self._team_conference = conferences_dict[team_name.lower()]
         self._parse_team_data(team_data)
@@ -138,7 +157,9 @@ class Team:
         """
         return self.__str__()
 
-    def _retrieve_team_data(self, year, team_name):
+    def _retrieve_team_data(self, year, team_name, basic_stats=None,
+                            basic_opp_stats=None, adv_stats=None,
+                            adv_opp_stats=None):
         """
         Pull all stats for a specific team.
 
@@ -153,6 +174,22 @@ class Team:
         team_name : string
             A ``string`` of the team's abbreviation, such as 'PURDUE' for the
             Purdue Boilermakers.
+        basic_stats : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Basic Stats page for the designated year.
+        basic_opp_stats : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Basic Opponent Stats page for the designated year.
+        adv_stats : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Advanced Stats page for the designated year.
+        adv_opp_stats : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Advanced Opponent Stats page for the designated year.
 
         Returns
         -------
@@ -160,7 +197,9 @@ class Team:
             Returns a PyQuery object containing all stats and information for
             the specified team.
         """
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, basic_stats,
+                                                   basic_opp_stats, adv_stats,
+                                                   adv_opp_stats)
         self._year = year
         team_data = team_data_dict[team_name]['data']
         return team_data
@@ -1036,12 +1075,31 @@ class Teams:
     ----------
     year : string (optional)
         The requested year to pull stats from.
+    basic_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should
+        be of the Basic Stats page for the designated year.
+    basic_opp_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should
+        be of the Basic Opponent Stats page for the designated year.
+    adv_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should
+        be of the Advanced Stats page for the designated year.
+    adv_opp_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should
+        be of the Advanced Opponent Stats page for the designated year.
     """
-    def __init__(self, year=None):
+    def __init__(self, year=None, basic_stats=None, basic_opp_stats=None,
+                 adv_stats=None, adv_opp_stats=None):
         self._teams = []
         self._conferences_dict = Conferences(year).team_conference
 
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, basic_stats,
+                                                   basic_opp_stats, adv_stats,
+                                                   adv_opp_stats)
         self._instantiate_teams(team_data_dict, year)
 
     def __getitem__(self, abbreviation):

--- a/sportsreference/ncaaf/ncaaf_utils.py
+++ b/sportsreference/ncaaf/ncaaf_utils.py
@@ -43,7 +43,7 @@ def _add_stats_data(teams_list, team_data_dict):
     return team_data_dict
 
 
-def _retrieve_all_teams(year):
+def _retrieve_all_teams(year, season_page, offensive_stats, defensive_stats):
     """
     Find and create Team instances for all teams in the given season.
 
@@ -60,6 +60,12 @@ def _retrieve_all_teams(year):
     ----------
     year : string
         The requested year to pull stats from.
+    season_page : string (optional)
+        Link with filename to the local season stats page.
+    offensive_stats : string (optional)
+        Link with filename to the local offensive stats page.
+    defensive_stats : string (optional)
+        Link with filename to the local defensive stats page.
 
     Returns
     -------
@@ -78,11 +84,11 @@ def _retrieve_all_teams(year):
         if not utils._url_exists(SEASON_PAGE_URL % year) and \
            utils._url_exists(SEASON_PAGE_URL % str(int(year) - 1)):
             year = str(int(year) - 1)
-    doc = pq(SEASON_PAGE_URL % year)
+    doc = utils._pull_page(SEASON_PAGE_URL % year, season_page)
     teams_list = utils._get_stats_table(doc, 'div#div_standings')
-    offense_doc = pq(OFFENSIVE_STATS_URL % year)
+    offense_doc = utils._pull_page(OFFENSIVE_STATS_URL % year, offensive_stats)
     offense_list = utils._get_stats_table(offense_doc, 'table#offense')
-    defense_doc = pq(DEFENSIVE_STATS_URL % year)
+    defense_doc = utils._pull_page(DEFENSIVE_STATS_URL % year, defensive_stats)
     defense_list = utils._get_stats_table(defense_doc, 'table#defense')
     if not teams_list and not offense_list and not defense_list:
         utils._no_data_found()

--- a/sportsreference/ncaaf/teams.py
+++ b/sportsreference/ncaaf/teams.py
@@ -32,9 +32,22 @@ class Team:
         A string of the team's conference abbreviation, such as 'big-12'.
     year : string (optional)
         The requested year to pull stats from.
+    season_page : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Season page for the designated year.
+    offensive_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Offensive Stats page for the designated year.
+    defensive_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Defensive Stats page for the designated year.
     """
     def __init__(self, team_name=None, team_data=None, team_conference=None,
-                 year=None):
+                 year=None, season_page=None, offensive_stats=None,
+                 defensive_stats=None):
         self._team_conference = team_conference
         self._year = year
         self._abbreviation = None
@@ -94,7 +107,9 @@ class Team:
         self._opponents_yards_from_penalties = None
 
         if team_name:
-            team_data = self._retrieve_team_data(year, team_name)
+            team_data = self._retrieve_team_data(year, team_name, season_page,
+                                                 offensive_stats,
+                                                 defensive_stats)
             conferences_dict = Conferences(year).team_conference
             self._team_conference = conferences_dict[team_name.lower()]
         self._parse_team_data(team_data)
@@ -111,7 +126,8 @@ class Team:
         """
         return self.__str__()
 
-    def _retrieve_team_data(self, year, team_name):
+    def _retrieve_team_data(self, year, team_name, season_page,
+                            offensive_stats, defensive_stats):
         """
         Pull all stats for a specific team.
 
@@ -126,6 +142,18 @@ class Team:
         team_name : string
             A ``string`` of the team's abbreviation, such as 'PURDUE' for the
             Purdue Boilermakers.
+        season_page : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Season page for the designated year.
+        offensive_stats : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Offensive Stats page for the designated year.
+        defensive_stats : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Defensive Stats page for the designated year.
 
         Returns
         -------
@@ -133,7 +161,9 @@ class Team:
             Returns a PyQuery object containing all stats and information for
             the specified team.
         """
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, season_page,
+                                                   offensive_stats,
+                                                   defensive_stats)
         self._year = year
         team_data = team_data_dict[team_name]['data']
         return team_data
@@ -712,12 +742,27 @@ class Teams:
     ----------
     year : string (optional)
         The requested year to pull stats from.
+    season_page : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Season page for the designated year.
+    offensive_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Offensive Stats page for the designated year.
+    defensive_stats : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Defensive Stats page for the designated year.
     """
-    def __init__(self, year=None):
+    def __init__(self, year=None, season_page=None, offensive_stats=None,
+                 defensive_stats=None):
         self._teams = []
         self._conferences_dict = Conferences(year, True).team_conference
 
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, season_page,
+                                                   offensive_stats,
+                                                   defensive_stats)
         self._instantiate_teams(team_data_dict, year)
 
     def __getitem__(self, abbreviation):

--- a/sportsreference/nfl/nfl_utils.py
+++ b/sportsreference/nfl/nfl_utils.py
@@ -40,7 +40,7 @@ def _add_stats_data(teams_list, team_data_dict):
     return team_data_dict
 
 
-def _retrieve_all_teams(year):
+def _retrieve_all_teams(year, season_page=None):
     """
     Find and create Team instances for all teams in the given season.
 
@@ -57,6 +57,8 @@ def _retrieve_all_teams(year):
     ----------
     year : string
         The requested year to pull stats from.
+    season_page : string (optional)
+        Link with filename to the local season page.
 
     Returns
     -------
@@ -75,7 +77,7 @@ def _retrieve_all_teams(year):
         if not utils._url_exists(SEASON_PAGE_URL % year) and \
            utils._url_exists(SEASON_PAGE_URL % str(int(year) - 1)):
             year = str(int(year) - 1)
-    doc = pq(SEASON_PAGE_URL % year)
+    doc = utils._pull_page(SEASON_PAGE_URL % year, season_page)
     teams_list = utils._get_stats_table(doc, 'div#all_team_stats')
     afc_list = utils._get_stats_table(doc, 'table#AFC')
     nfc_list = utils._get_stats_table(doc, 'table#NFC')

--- a/sportsreference/nfl/teams.py
+++ b/sportsreference/nfl/teams.py
@@ -42,8 +42,13 @@ class Team:
         A team's position in the league based on the number of points they
         obtained during the season. Is only used when called directly from the
         Teams class.
+    season_page : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Season page for the designated year.
     """
-    def __init__(self, team_name=None, team_data=None, rank=None, year=None):
+    def __init__(self, team_name=None, team_data=None, rank=None, year=None,
+                 season_page=None):
         self._year = year
         self._rank = rank
         self._abbreviation = None
@@ -86,7 +91,7 @@ class Team:
         self._points_contributed_by_offense = None
 
         if team_name:
-            team_data = self._retrieve_team_data(year, team_name)
+            team_data = self._retrieve_team_data(year, team_name, season_page)
         self._parse_team_data(team_data)
 
     def __str__(self):
@@ -101,7 +106,7 @@ class Team:
         """
         return self.__str__()
 
-    def _retrieve_team_data(self, year, team_name):
+    def _retrieve_team_data(self, year, team_name, season_page):
         """
         Pull all stats for a specific team.
 
@@ -116,6 +121,10 @@ class Team:
         team_name : string
             A ``string`` of the team's 3-letter abbreviation, such as 'KAN' for
             the Kansas City Chiefs.
+        season_page : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Season page for the designated year.
 
         Returns
         -------
@@ -123,7 +132,7 @@ class Team:
             Returns a PyQuery object containing all stats and information for
             the specified team.
         """
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, season_page)
         self._year = year
         team_data = team_data_dict[team_name]['data']
         self._rank = team_data_dict[team_name]['rank']
@@ -578,11 +587,15 @@ class Teams:
     ----------
     year : string (optional)
         The requested year to pull stats from.
+    season_page : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Season page for the designated year.
     """
-    def __init__(self, year=None):
+    def __init__(self, year=None, season_page=None):
         self._teams = []
 
-        team_data_dict, year = _retrieve_all_teams(year)
+        team_data_dict, year = _retrieve_all_teams(year, season_page)
         self._instantiate_teams(team_data_dict, year)
 
     def __getitem__(self, abbreviation):

--- a/sportsreference/nhl/nhl_utils.py
+++ b/sportsreference/nhl/nhl_utils.py
@@ -3,7 +3,7 @@ from sportsreference import utils
 from .constants import SEASON_PAGE_URL
 
 
-def _retrieve_all_teams(year):
+def _retrieve_all_teams(year, season_page=None):
     """
     Find and create Team instances for all teams in the given season.
 
@@ -19,6 +19,8 @@ def _retrieve_all_teams(year):
     ----------
     year : string
         The requested year to pull stats from.
+    teams_file : string (optional)
+        Link with filename to the local season page.
 
     Returns
     -------
@@ -35,7 +37,7 @@ def _retrieve_all_teams(year):
         if not utils._url_exists(SEASON_PAGE_URL % year) and \
            utils._url_exists(SEASON_PAGE_URL % str(int(year) - 1)):
             year = str(int(year) - 1)
-    doc = pq(SEASON_PAGE_URL % year)
+    doc = utils._pull_page(SEASON_PAGE_URL % year, season_page)
     teams_list = utils._get_stats_table(doc, 'div#all_stats')
     if not teams_list:
         utils._no_data_found()

--- a/sportsreference/nhl/teams.py
+++ b/sportsreference/nhl/teams.py
@@ -35,8 +35,13 @@ class Team:
     year : string (optional)
         The requested year to pull stats from. Is only used when called
         directly from the Teams class.
+    season_page : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Season page for the designated year.
     """
-    def __init__(self, team_name=None, team_data=None, rank=None, year=None):
+    def __init__(self, team_name=None, team_data=None, rank=None, year=None,
+                 season_page=None):
         self._year = year
         self._rank = rank
         self._abbreviation = None
@@ -68,7 +73,7 @@ class Team:
         self._pdo_at_even_strength = None
 
         if team_name:
-            team_data = self._retrieve_team_data(year, team_name)
+            team_data = self._retrieve_team_data(year, team_name, season_page)
         self._parse_team_data(team_data)
 
     def __str__(self):
@@ -83,7 +88,7 @@ class Team:
         """
         return self.__str__()
 
-    def _retrieve_team_data(self, year, team_name):
+    def _retrieve_team_data(self, year, team_name, season_page):
         """
         Pull all stats for a specific team.
 
@@ -98,8 +103,12 @@ class Team:
         team_name : string
             A ``string`` of the team's 3-letter abbreviation, such as 'DET' for
             the Detroit Red Wings.
+        season_page : string (optional)
+            Optionally specify the filename of a local file to use to pull data
+            instead of downloading from sports-reference.com. This file should
+            be of the Season page for the designated year.
         """
-        teams_list, year = _retrieve_all_teams(year)
+        teams_list, year = _retrieve_all_teams(year, season_page)
         self._year = year
         # Teams are listed in terms of rank with the first team being #1
         rank = 1
@@ -438,11 +447,15 @@ class Teams:
     ----------
     year : string (optional)
         The requested year to pull stats from.
+    season_page : string (optional)
+        Optionally specify the filename of a local file to use to pull data
+        instead of downloading from sports-reference.com. This file should be
+        of the Season page for the designated year.
     """
-    def __init__(self, year=None):
+    def __init__(self, year=None, season_page=None):
         self._teams = []
 
-        teams_list, year = _retrieve_all_teams(year)
+        teams_list, year = _retrieve_all_teams(year, season_page)
         self._instantiate_teams(teams_list, year)
 
     def __getitem__(self, abbreviation):

--- a/sportsreference/utils.py
+++ b/sportsreference/utils.py
@@ -267,6 +267,42 @@ def _get_stats_table(html_page, div, footer=False):
     return teams_list
 
 
+def _pull_page(url=None, local_file=None):
+    """
+    Pull data from a local file if exists, or download data from the website.
+
+    If local_file is passed, users can pull data directly from a local file
+    which has already been downloaded instead of downloading from
+    sports-reference.com using the package. This reduces server load on their
+    end, and allows package users to work offline.
+
+    Parameters
+    ----------
+    url : string (optional)
+        A ``string`` of the URL to pull data from.
+    local_file : string (optional)
+        A link to a local file which has been pre-downloaded from the website.
+
+    Returns
+    -------
+    PyQuery object
+        Returns a ``PyQuery`` object representing the file that was either
+        downloaded or read.
+
+    Raises
+    ------
+    ValueError
+        Raises a ``ValueError`` if neither the URL nor the local_file
+        parameters were specified.
+    """
+    if local_file:
+        with open(local_file, 'r', encoding='utf8') as filehandle:
+            return pq(filehandle.read())
+    if url:
+        return pq(url)
+    raise ValueError('Expected either a URL or a local data file!')
+
+
 def _no_data_found():
     """
     Print a message that no data could be found on the page.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from mock import patch
 from flexmock import flexmock
 from sportsreference import utils
@@ -291,3 +292,12 @@ class TestUtils:
         response = utils._no_data_found()
 
         assert not response
+
+    def test_pulling_data_with_no_inputs(self, *args, **kwargs):
+        with pytest.raises(ValueError):
+            utils._pull_page()
+
+    def test_pulling_local_file(seld, *args, **kwargs):
+        output = utils._pull_page(local_file='VERSION')
+
+        assert output


### PR DESCRIPTION
To reduce server load on sports-reference.com, users should be allowed to pass local data files which are cached versions of the webpages to the classes. This also enables users to work offline without relying on the website for a connection.

Fixes #9

Signed-Off-By: Robert Clark <robdclark@outlook.com>