### PR TITLE
Fix NFL players wrongly being listed as away

### DIFF
--- a/sportsreference/nfl/constants.py
+++ b/sportsreference/nfl/constants.py
@@ -80,6 +80,7 @@ BOXSCORE_SCHEME = {
     'game_details': 'table#game_info tr',
     'home_name': 'a[itemprop="name"]:first',
     'summary': 'table[class="linescore nohover stats_table no_freeze"]:first',
+    'team_stats': 'table#team_stats thead',
     'away_name': 'a[itemprop="name"]:last',
     'away_points': 'div[class="scorebox"] div[class="score"]',
     'away_first_downs': 'td[data-stat="vis_stat"]',

--- a/tests/unit/test_nfl_boxscore.py
+++ b/tests/unit/test_nfl_boxscore.py
@@ -110,9 +110,7 @@ class TestNFLBoxscore:
             .and_return(expected_name)
 
         fake_winner = PropertyMock(return_value=HOME)
-        fake_home_abbr = PropertyMock(return_value=MockName(expected_name))
         type(self.boxscore).winner = fake_winner
-        type(self.boxscore)._home_abbr = fake_home_abbr
 
         assert self.boxscore.winning_abbr == expected_name
 
@@ -124,9 +122,7 @@ class TestNFLBoxscore:
             .and_return(expected_name)
 
         fake_winner = PropertyMock(return_value=AWAY)
-        fake_away_abbr = PropertyMock(return_value=MockName(expected_name))
         type(self.boxscore).winner = fake_winner
-        type(self.boxscore)._away_abbr = fake_away_abbr
 
         assert self.boxscore.winning_abbr == expected_name
 
@@ -158,9 +154,7 @@ class TestNFLBoxscore:
             .and_return(expected_name)
 
         fake_winner = PropertyMock(return_value=AWAY)
-        fake_home_abbr = PropertyMock(return_value=MockName(expected_name))
         type(self.boxscore).winner = fake_winner
-        type(self.boxscore)._home_abbr = fake_home_abbr
 
         assert self.boxscore.losing_abbr == expected_name
 
@@ -172,9 +166,7 @@ class TestNFLBoxscore:
             .and_return(expected_name)
 
         fake_winner = PropertyMock(return_value=HOME)
-        fake_away_abbr = PropertyMock(return_value=MockName(expected_name))
         type(self.boxscore).winner = fake_winner
-        type(self.boxscore)._away_abbr = fake_away_abbr
 
         assert self.boxscore.losing_abbr == expected_name
 
@@ -323,6 +315,26 @@ itemprop="name">New England Patriots</a>')
 
         for field, value in fields.items():
             assert getattr(self.boxscore, field) == value
+
+    def test_finding_home_team_with_no_abbrs(self):
+        mock_html = pq('<td data-stat="team">KAN</td>')
+        abbr = PropertyMock(return_value='KAN')
+        self.boxscore._home_abbr = None
+        self.boxscore._away_abbr = None
+        type(self.boxscore).home_abbreviation = abbr
+        team = self.boxscore._find_home_or_away(mock_html)
+
+        assert team == HOME
+
+    def test_finding_away_team_with_no_abbrs(self):
+        mock_html = pq('<td data-stat="team">HTX</td>')
+        abbr = PropertyMock(return_value='KAN')
+        self.boxscore._home_abbr = None
+        self.boxscore._away_abbr = None
+        type(self.boxscore).home_abbreviation = abbr
+        team = self.boxscore._find_home_or_away(mock_html)
+
+        assert team == AWAY
 
 
 class TestNFLBoxscores:


### PR DESCRIPTION
Occasionally, some NFL Boxscores would incorrectly list the home team players as away. This is caused by the home and away teams using different abbreviations in their URIs than the abbreviations listed in the tables, which would fail the branching logic to select the players for a specific team.

By checking the abbreviations listed on the actual page outside of the URIs, the players can be placed properly into one team or the other.

Fixes #501

Signed-Off-By: Robert Clark <robdclark@outlook.com>