### PR TITLE
Update default values for NBA players

### DIFF
--- a/sportsreference/nba/player.py
+++ b/sportsreference/nba/player.py
@@ -24,10 +24,10 @@ def _int_property_decorator(func):
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
-        value = _cleanup(prop[index])
         try:
+            value = _cleanup(prop[index])
             return int(value)
-        except ValueError:
+        except (TypeError, ValueError):
             # If there is no value, default to None
             return None
     return wrapper
@@ -39,10 +39,10 @@ def _float_property_decorator(func):
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
-        value = _cleanup(prop[index])
         try:
+            value = _cleanup(prop[index])
             return float(value)
-        except ValueError:
+        except (TypeError, ValueError):
             # If there is no value, default to None
             return None
     return wrapper
@@ -119,6 +119,8 @@ class AbstractPlayer:
         self._usage_percentage = None
         self._box_plus_minus = None
 
+        if not player_data:
+            return
         self._parse_player_data(player_data)
 
     def _parse_value(self, stats, field):

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -28,10 +28,10 @@ def _int_property_decorator(func):
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
-        value = _cleanup(prop[index])
         try:
+            value = _cleanup(prop[index])
             return int(value)
-        except ValueError:
+        except (TypeError, ValueError):
             # If there is no value, default to None
             return None
     return wrapper
@@ -43,10 +43,10 @@ def _int_property_decorator_default_zero(func):
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
-        value = _cleanup(prop[index])
         try:
+            value = _cleanup(prop[index])
             return int(value)
-        except ValueError:
+        except (TypeError, ValueError):
             # If there is no value, default to 0
             return 0
     return wrapper
@@ -58,10 +58,10 @@ def _float_property_decorator(func):
     def wrapper(*args):
         index = args[0]._index
         prop = func(*args)
-        value = _cleanup(prop[index])
         try:
+            value = _cleanup(prop[index])
             return float(value)
-        except ValueError:
+        except (TypeError, ValueError):
             # If there is no value, default to None
             return None
     return wrapper
@@ -186,10 +186,10 @@ class Player(AbstractPlayer):
         self._points_per_poss = None
 
         player_data = self._pull_player_data()
+        AbstractPlayer.__init__(self, player_id, self._name, player_data)
         if not player_data:
             return
         self._find_initial_index()
-        AbstractPlayer.__init__(self, player_id, self._name, player_data)
 
     def __str__(self):
         """


### PR DESCRIPTION
In cases where no information is present for an NBA player, the default value of `None` should be used for all attributes. At present, the code was unable to initialize many default common variables for players, which resulted in an error while trying to pull data from the `Roster` class.

Fixes #456

Signed-Off-By: Robert Clark <robdclark@outlook.com>