### PR TITLE
Add coach to Roster

### DIFF
--- a/sportsreference/mlb/constants.py
+++ b/sportsreference/mlb/constants.py
@@ -306,6 +306,7 @@ BOXSCORE_ELEMENT_INDEX = {
 }
 
 PLAYER_SCHEME = {
+    'summary': '[data-template="Partials/Teams/Summary"]',
     'season': 'th[data-stat="year_ID"]',
     'name': 'h1[itemprop="name"]',
     'team_abbreviation': 'td[data-stat="team_ID"]',

--- a/sportsreference/mlb/roster.py
+++ b/sportsreference/mlb/roster.py
@@ -1450,12 +1450,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self._coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def __str__(self):
         """
@@ -1555,7 +1556,29 @@ class Roster:
         name_tag = player('td[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _parse_coach(self, page):
+        """
+        Parse the team's coach.
+
+        Given a copy of the team's roster page, find and parse the team's
+        coach from the team summary.
+
+        Parameters
+        ----------
+        page : PyQuery object
+            A PyQuery object representing the team's roster page.
+
+        Returns
+        -------
+        string
+            Returns a string of the coach's name.
+        """
+        for line in page(PLAYER_SCHEME['summary']).find('p').items():
+            strong = line.find('strong')
+            if hasattr(strong, 'text') and strong.text().strip() == 'Manager:':
+                return line.find('a').text()
+
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1614,6 +1637,8 @@ class Roster:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
 
+        self._coach = self._parse_coach(page)
+
     @property
     def players(self):
         """
@@ -1624,3 +1649,10 @@ class Roster:
         first and last name as listed on the roster page.
         """
         return self._players
+
+    @property
+    def coach(self):
+        """
+        Returns a ``string`` of the coach's name, such as 'AJ Hinch'.
+        """
+        return self._coach

--- a/sportsreference/nba/constants.py
+++ b/sportsreference/nba/constants.py
@@ -191,6 +191,7 @@ BOXSCORE_ELEMENT_INDEX = {
 }
 
 PLAYER_SCHEME = {
+    'summary': '[data-template="Partials/Teams/Summary"]',
     'season': 'th[data-stat="season"]:first',
     'name': 'h1',
     'team_abbreviation': 'td[data-stat="team_id"]',

--- a/sportsreference/nba/nba_utils.py
+++ b/sportsreference/nba/nba_utils.py
@@ -84,6 +84,7 @@ def _retrieve_all_teams(year, season_file=None):
     doc = utils._pull_page(SEASON_PAGE_URL % year, season_file)
     teams_list = utils._get_stats_table(doc, 'div#all_team-stats-base')
     opp_teams_list = utils._get_stats_table(doc, 'div#all_opponent-stats-base')
+
     if not teams_list and not opp_teams_list:
         utils._no_data_found()
         return None, None

--- a/sportsreference/nba/roster.py
+++ b/sportsreference/nba/roster.py
@@ -1384,12 +1384,12 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self._coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
-
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def __str__(self):
         """
@@ -1489,7 +1489,29 @@ class Roster:
         name_tag = player('td[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _parse_coach(self, page):
+        """
+        Parse the team's coach.
+
+        Given a copy of the team's roster page, find and parse the team's
+        coach from the team summary.
+
+        Parameters
+        ----------
+        page : PyQuery object
+            A PyQuery object representing the team's roster page.
+
+        Returns
+        -------
+        string
+            Returns a string of the coach's name.
+        """
+        for line in page(PLAYER_SCHEME['summary']).find('p').items():
+            strong = line.find('strong')
+            if hasattr(strong, 'text') and strong.text().strip() == 'Coach:':
+                return line.find('a').text()
+
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1541,6 +1563,8 @@ class Roster:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
 
+        self._coach = self._parse_coach(page)
+
     @property
     def players(self):
         """
@@ -1551,3 +1575,10 @@ class Roster:
         first and last name as listed on the roster page.
         """
         return self._players
+
+    @property
+    def coach(self):
+        """
+        Returns a ``string`` of the coach's name, such as "Mike D'Antoni".
+        """
+        return self._coach

--- a/sportsreference/ncaab/constants.py
+++ b/sportsreference/ncaab/constants.py
@@ -247,6 +247,7 @@ RANKINGS_SCHEME = {
 }
 
 PLAYER_SCHEME = {
+    'summary': '[data-template="Partials/Teams/Summary"]',
     'conference': 'td[data-stat="conf_abbr"]',
     'season': 'th[data-stat="season"]:first',
     'name': 'h1',

--- a/sportsreference/ncaab/roster.py
+++ b/sportsreference/ncaab/roster.py
@@ -656,12 +656,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self._coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def __str__(self):
         """
@@ -761,7 +762,29 @@ class Roster:
         name_tag = player('th[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _parse_coach(self, page):
+        """
+        Parse the team's coach.
+
+        Given a copy of the team's roster page, find and parse the team's
+        coach from the team summary.
+
+        Parameters
+        ----------
+        page : PyQuery object
+            A PyQuery object representing the team's roster page.
+
+        Returns
+        -------
+        string
+            Returns a string of the coach's name.
+        """
+        for line in page(PLAYER_SCHEME['summary']).find('p').items():
+            strong = line.find('strong')
+            if hasattr(strong, 'text') and strong.text().strip() == 'Coach:':
+                return line.find('a').text()
+
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -802,6 +825,8 @@ class Roster:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
 
+        self._coach = self._parse_coach(page)
+
     @property
     def players(self):
         """
@@ -812,3 +837,10 @@ class Roster:
         first and last name as listed on the roster page.
         """
         return self._players
+
+    @property
+    def coach(self):
+        """
+        Returns a ``string`` of the coach's name, such as 'Matt Painter'.
+        """
+        return self._coach

--- a/sportsreference/ncaaf/constants.py
+++ b/sportsreference/ncaaf/constants.py
@@ -247,6 +247,7 @@ BOXSCORE_ELEMENT_SUB_INDEX = {
 }
 
 PLAYER_SCHEME = {
+    'summary': '[data-template="Partials/Teams/Summary"]',
     'season': 'th[data-stat="year_id"]',
     'name': 'h1[itemprop="name"]',
     'team_abbreviation': 'td[data-stat="school_name"]',

--- a/sportsreference/ncaaf/roster.py
+++ b/sportsreference/ncaaf/roster.py
@@ -883,12 +883,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self._coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def __str__(self):
         """
@@ -988,7 +989,29 @@ class Roster:
         name_tag = player('th[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _parse_coach(self, page):
+        """
+        Parse the team's coach.
+
+        Given a copy of the team's roster page, find and parse the team's
+        coach from the team summary.
+
+        Parameters
+        ----------
+        page : PyQuery object
+            A PyQuery object representing the team's roster page.
+
+        Returns
+        -------
+        string
+            Returns a string of the coach's name.
+        """
+        for line in page(PLAYER_SCHEME['summary']).find('p').items():
+            strong = line.find('strong')
+            if hasattr(strong, 'text') and strong.text().strip() == 'Coach:':
+                return line.find('a').text()
+
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1028,6 +1051,8 @@ class Roster:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
 
+        self._coach = self._parse_coach(page)
+
     @property
     def players(self):
         """
@@ -1038,3 +1063,10 @@ class Roster:
         first and last name as listed on the roster page.
         """
         return self._players
+
+    @property
+    def coach(self):
+        """
+        Returns a ``string`` of the coach's name, such as 'Jeff Brohm'.
+        """
+        return self._coach

--- a/sportsreference/nfl/constants.py
+++ b/sportsreference/nfl/constants.py
@@ -229,6 +229,7 @@ BOXSCORE_ELEMENT_SUB_INDEX = {
 }
 
 PLAYER_SCHEME = {
+    'summary': '[data-template="Partials/Teams/Summary"]',
     'season': 'th[data-stat="year_id"]',
     'name': 'h1[itemprop="name"]',
     'team_abbreviation': 'td[data-stat="team"]',

--- a/sportsreference/nfl/roster.py
+++ b/sportsreference/nfl/roster.py
@@ -1708,12 +1708,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self._coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def __str__(self):
         """
@@ -1813,7 +1814,29 @@ class Roster:
         name_tag = player('td[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _parse_coach(self, page):
+        """
+        Parse the team's coach.
+
+        Given a copy of the team's roster page, find and parse the team's
+        coach from the team summary.
+
+        Parameters
+        ----------
+        page : PyQuery object
+            A PyQuery object representing the team's roster page.
+
+        Returns
+        -------
+        string
+            Returns a string of the coach's name.
+        """
+        for line in page(PLAYER_SCHEME['summary']).find('p').items():
+            strong = line.find('strong')
+            if hasattr(strong, 'text') and strong.text().strip() == 'Coach:':
+                return line.find('a').text()
+
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1853,6 +1876,8 @@ class Roster:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
 
+        self._coach = self._parse_coach(page)
+
     @property
     def players(self):
         """
@@ -1863,3 +1888,10 @@ class Roster:
         first and last name as listed on the roster page.
         """
         return self._players
+
+    @property
+    def coach(self):
+        """
+        Returns a ``string`` of the coach's name, such as 'Sean Payton'.
+        """
+        return self._coach

--- a/sportsreference/nhl/constants.py
+++ b/sportsreference/nhl/constants.py
@@ -122,6 +122,7 @@ BOXSCORE_ELEMENT_INDEX = {
 }
 
 PLAYER_SCHEME = {
+    'summary': '[data-template="Partials/Teams/Summary"]',
     'season': 'th[data-stat="season"]',
     'name': 'h1[itemprop="name"]',
     'team_abbreviation': 'td[data-stat="team_id"]',

--- a/sportsreference/nhl/roster.py
+++ b/sportsreference/nhl/roster.py
@@ -1105,12 +1105,13 @@ class Roster:
     def __init__(self, team, year=None, slim=False):
         self._team = team
         self._slim = slim
+        self._coach = None
         if slim:
             self._players = {}
         else:
             self._players = []
 
-        self._find_players(year)
+        self._find_players_with_coach(year)
 
     def __str__(self):
         """
@@ -1208,7 +1209,29 @@ class Roster:
         name_tag = player('td[data-stat="player"] a')
         return name_tag.text()
 
-    def _find_players(self, year):
+    def _parse_coach(self, page):
+        """
+        Parse the team's coach.
+
+        Given a copy of the team's roster page, find and parse the team's
+        coach from the team summary.
+
+        Parameters
+        ----------
+        page : PyQuery object
+            A PyQuery object representing the team's roster page.
+
+        Returns
+        -------
+        string
+            Returns a string of the coach's name.
+        """
+        for line in page(PLAYER_SCHEME['summary']).find('p').items():
+            strong = line.find('strong')
+            if hasattr(strong, 'text') and strong.text().strip() == 'Coach:':
+                return line.find('a').text()
+
+    def _find_players_with_coach(self, year):
         """
         Find all player IDs for the requested team.
 
@@ -1248,6 +1271,8 @@ class Roster:
                 player_instance = Player(player_id)
                 self._players.append(player_instance)
 
+        self._coach = self._parse_coach(page)
+
     @property
     def players(self):
         """
@@ -1258,3 +1283,10 @@ class Roster:
         first and last name as listed on the roster page.
         """
         return self._players
+
+    @property
+    def coach(self):
+        """
+        Returns a ``string`` of the coach's name, such as 'Jeff Blashill'.
+        """
+        return self._coach

--- a/tests/integration/roster/test_mlb_roster.py
+++ b/tests/integration/roster/test_mlb_roster.py
@@ -1251,3 +1251,6 @@ José Altuve (mortoch02)"""
         roster = Roster('HOU')
 
         assert roster.__repr__() == expected
+
+    def test_coach(self):
+        assert "AJ Hinch" == Roster('HOU', year=YEAR).coach

--- a/tests/integration/roster/test_nba_roster.py
+++ b/tests/integration/roster/test_nba_roster.py
@@ -1326,3 +1326,6 @@ James Harden (hardeja01)"""
         roster = Roster('HOU')
 
         assert roster.__repr__() == expected
+
+    def test_coach(self):
+        assert "Mike D'Antoni" == Roster('HOU').coach

--- a/tests/integration/roster/test_ncaab_roster.py
+++ b/tests/integration/roster/test_ncaab_roster.py
@@ -445,3 +445,6 @@ Vince Edwards (vince-edwards-2)"""
         roster = Roster('PURDUE')
 
         assert roster.__repr__() == expected
+
+    def test_coach(self):
+        assert "Matt Painter" == Roster('PURDUE', year=YEAR).coach

--- a/tests/integration/roster/test_ncaaf_roster.py
+++ b/tests/integration/roster/test_ncaaf_roster.py
@@ -574,3 +574,6 @@ David Blough (rondale-moore-1)"""
         roster = Roster('PURDUE')
 
         assert roster.__repr__() == expected
+
+    def test_coach(self):
+        assert "Troy Calhoun" == Roster('air-force', year=YEAR).coach

--- a/tests/integration/roster/test_nfl_roster.py
+++ b/tests/integration/roster/test_nfl_roster.py
@@ -1496,3 +1496,6 @@ Thomas Morstead (MorsTh00)"""
         roster = Roster('NOR')
 
         assert roster.__repr__() == expected
+
+    def test_coach(self):
+        assert "Sean Payton" == Roster('NOR', year=YEAR).coach

--- a/tests/integration/roster/test_nhl_roster.py
+++ b/tests/integration/roster/test_nhl_roster.py
@@ -756,3 +756,6 @@ Henrik Zetterberg (zettehe01)"""
         roster = Roster('DET')
 
         assert roster.__repr__() == expected
+
+    def test_coach(self):
+        assert "Jeff Blashill" == Roster('DET', year=YEAR).coach


### PR DESCRIPTION
The coach or manager's full name is now a property that can be retrieved from a team's Roster class.

Closes #285