### PR TITLE
Fix issue pulling football league positions

### DIFF
--- a/sportsreference/fb/team.py
+++ b/sportsreference/fb/team.py
@@ -165,12 +165,15 @@ class Team:
         records = record_line.lower().replace('record: ', '')
         records_split = records.split(',')
         if len(records_split) != 3:
-            return None, None, None
+            return None, None, None, None
         record, points, position = records_split
         points = re.sub(' point.*', '', points).strip()
         position = re.sub(r'\(.*\)', '', position).strip()
         league = re.sub('.* in ', '', position).title()
-        position = re.findall(r'\d+', position)[0]
+        try:
+            position = re.findall(r'\d+', position)[0]
+        except IndexError:
+            position = None
         return record, points, position, league
 
     def _goals(self, goals_line):

--- a/tests/unit/test_fb_team.py
+++ b/tests/unit/test_fb_team.py
@@ -52,7 +52,14 @@ class TestFBTeam:
 
         output = self.team._records(html)
 
-        assert output == (None, None, None)
+        assert output == (None, None, None, None)
+
+    def test_records_missing_position(self):
+        html = 'Record: 5-0-0, 15 points (3.0 per game),  Premier League'
+
+        output = self.team._records(html)
+
+        assert output == ('5-0-0', '15', None, 'Premier League')
 
     def test_goals_missing(self):
         html = 'Goals: 20 (2.5 per game), Goals Against: 11 (1.38 per game)'


### PR DESCRIPTION
Occasionally, a team's league position will not be posted on their team page, throwing an error while attempting to parse that information. Defaulting the value to `None` in this scenario will skip the error while allowing expected functionality to continue.

Fixes #530 

Signed-Off-By: Robert Clark <robdclark@outlook.com>