### PR TITLE
Fix issue pulling future NFL boxscores

### DIFF
--- a/sportsreference/nfl/boxscore.py
+++ b/sportsreference/nfl/boxscore.py
@@ -729,6 +729,8 @@ class Boxscore:
         for column in game_info('th').items():
             if column.text():
                 abbreviations.append(column.text())
+        if not abbreviations:
+            return None, None
         return abbreviations
 
     def _parse_game_data(self, uri):

--- a/tests/unit/test_nfl_boxscore.py
+++ b/tests/unit/test_nfl_boxscore.py
@@ -336,6 +336,12 @@ itemprop="name">New England Patriots</a>')
 
         assert team == AWAY
 
+    def test_missing_abbreviations(self):
+        table = '<table id="team_stats"><thead></thead></table>'
+        output = self.boxscore._alt_abbreviations(pq(table))
+
+        assert output == (None, None)
+
 
 class TestNFLBoxscores:
     @patch('requests.get', side_effect=mock_pyquery)


### PR DESCRIPTION
For NFL games that are scheduled but have not yet taken place, the code would take the preview link for the game and treat it as the Boxscore link, causing errors to be thrown while attempt to pull Boxscore data from the preview which doesn't have the intended information.

Fixes #531 

Signed-Off-By: Robert Clark <robdclark@outlook.com>