### PR TITLE
Handle redirects to 404 errors

### DIFF
--- a/sportsreference/utils.py
+++ b/sportsreference/utils.py
@@ -61,7 +61,13 @@ def _url_exists(url):
     """
     try:
         response = requests.head(url)
-        if response.status_code < 400:
+        if response.status_code == 301:
+            response = requests.get(url)
+            if response.status_code < 400:
+                return True
+            else:
+                return False
+        elif response.status_code < 400:
             return True
         else:
             return False


### PR DESCRIPTION
If the code throws a 301 redirect error which leads to a 404 error, it will be treated as the request returning a valid result, when that shouldn't be the case. By pulling the page on a status code of 301, the final value is returned for the `status_code`, which in the case of a 404 error, will return the intended value.

Fixes #533 

Signed-Off-By: Robert Clark <robdclark@outlook.com>