### PR TITLE
Fix incorrect squad IDs for football

### DIFF
--- a/sportsreference/fb/squad_ids.py
+++ b/sportsreference/fb/squad_ids.py
@@ -1340,7 +1340,7 @@ SQUAD_IDS = {
     'malmesbury victoria': 'd0710d5b',
     'maltby main': 'e5c50549',
     'malvern town': '6c4ff7a2',
-    'manchester city': '9ce68f8a',
+    'manchester city': 'b8fd03ef',
     'manchester city u23': 'e41e516f',
     'manchester city wfc': '9ce68f8a',
     'manchester united': '19538871',


### PR DESCRIPTION
Some teams had the incorrect squad IDs in the football section, making it appear they didn't exist.

Fixes #515 

Signed-Off-By: Robert Clark <robdclark@outlook.com>