### PR TITLE
Encode FB player names in exhaustive tests

### DIFF
--- a/tests/exhaustive/fb_tests.py
+++ b/tests/exhaustive/fb_tests.py
@@ -9,4 +9,4 @@ for team in list(set(SQUAD_IDS.values())):
     for game in squad.schedule:
         print(game.date)
     for player in squad.roster:
-        print(player.name)
+        print(player.name.encode('utf-8'))


### PR DESCRIPTION
Some player names fail to encode in the exhaustive Windows tests, causing the test to fail. Forcing UTF-8 encoding allows the tests to continue as expected.

Fixes #537 

Signed-Off-By: Robert Clark <robdclark@outlook.com>