### PR TITLE
Encode NCAAB player names

### DIFF
--- a/tests/exhaustive/ncaab_tests.py
+++ b/tests/exhaustive/ncaab_tests.py
@@ -7,7 +7,7 @@ from sportsipy.ncaab.teams import Teams
 for team in Teams():
     print(team.name)
     for player in team.roster.players:
-        print(player.name)
+        print(player.name.encode('utf-8'))
     for game in team.schedule:
         print(game.dataframe)
         print(game.dataframe_extended)


### PR DESCRIPTION
Windows is unable to handle certain NCAAB player names in the exhaustive tests, and need to be specially handled.

Signed-Off-By: Robert Clark <robdclark@outlook.com>