### PR TITLE
Encode exhaustive football tests

### DIFF
--- a/tests/exhaustive/fb_tests.py
+++ b/tests/exhaustive/fb_tests.py
@@ -5,7 +5,7 @@ from sportsipy.fb.squad_ids import SQUAD_IDS
 
 for team in list(set(SQUAD_IDS.values())):
     squad = Team(team)
-    print(squad.name)
+    print(squad.name.encode('utf-8'))
     for game in squad.schedule:
         print(game.date)
     for player in squad.roster:


### PR DESCRIPTION
A few squad names are unable to be properly encoded on Windows for the exhaustive football tests and need to be specially handled.

Signed-Off-By: Robert Clark <robdclark@outlook.com>